### PR TITLE
Avoid `mmcv` build error due to unspecified `TORCH_CUDA_ARCH_LIST`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official implementation of [our paper](https://arxiv.org/abs/2305.08366) "CL
 
 ## Method
 
-CLRerNet features LaneIoU for the target assignment cost and loss functions aiming at the improved quality of confidence scores.   
+CLRerNet features LaneIoU for the target assignment cost and loss functions aiming at the improved quality of confidence scores.
 LaneIoU takes the local lane angles into consideration to better correlate with the segmentation-based IoU metric.
 
 <p align="left"> <img src="docs/figures/clrernet.jpg" height="200"\></p>
@@ -17,11 +17,11 @@ LaneIoU takes the local lane angles into consideration to better correlate with 
 
 CLRerNet achieves the <b>state-of-the-art performance on CULane benchmark </b> significantly surpassing the baseline.
 
-Model           | Backbone | F1 score | GFLOPs 
----             | ---      | ---           | ---   
-CLRNet        | DLA34    | 80.47  | 18.4   
-[CLRerNet](https://github.com/hirotomusiker/CLRerNet/releases/download/v0.1.0/clrernet_culane_dla34.pth)        | DLA34    | 81.12&pm;0.04 <sup>*</sup>| 18.4   
-[CLRerNet&#8902;](https://github.com/hirotomusiker/CLRerNet/releases/download/v0.1.0/clrernet_culane_dla34_ema.pth) | DLA34    | 81.43&pm;0.14 <sup>*</sup> | 18.4   
+Model           | Backbone | F1 score | GFLOPs
+---             | ---      | ---           | ---
+CLRNet        | DLA34    | 80.47  | 18.4
+[CLRerNet](https://github.com/hirotomusiker/CLRerNet/releases/download/v0.1.0/clrernet_culane_dla34.pth)        | DLA34    | 81.12&pm;0.04 <sup>*</sup>| 18.4
+[CLRerNet&#8902;](https://github.com/hirotomusiker/CLRerNet/releases/download/v0.1.0/clrernet_culane_dla34_ema.pth) | DLA34    | 81.43&pm;0.14 <sup>*</sup> | 18.4
 
 
 \* F1 score stats of five models reported in our paper. The release models' scores are 81.11 (CLRerNet) and 81.55 (CLRerNet&#8902;, EMA model) respectively.
@@ -30,7 +30,11 @@ CLRNet        | DLA34    | 80.47  | 18.4
 
 Docker environment is recommended for installation:
 ```bash
-docker-compose build --build-arg UID="`id -u`" dev
+docker-compose build \
+--build-arg UID="`id -u`" \
+--build-arg TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6" \
+dev
+
 docker-compose run --rm dev
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
+ARG TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6
+
 # packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -40,7 +42,7 @@ ARG MMDET_VERSION
 WORKDIR /home/docker/
 RUN pip install Cython
 RUN git clone https://github.com/open-mmlab/mmdetection.git mmdetection -b v${MMDET_VERSION} --depth 1
-WORKDIR mmdetection
+WORKDIR /home/docker/mmdetection
 ENV FORCE_CUDA="1"
 RUN pip install --no-cache-dir -e .
 


### PR DESCRIPTION
Avoid `mmcv` build error due to unspecified `TORCH_CUDA_ARCH_LIST`
If not specified, the following error is likely to occur when running `docker-compose build` or `docker compose build`.

```bash
#25 11.14 Traceback (most recent call last):
#25 11.14   File "/tmp/nms/setup.py", line 5, in <module>
#25 11.14     setup(
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/__init__.py", line 107, in setup
#25 11.14     return distutils.core.setup(**attrs)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 185, in setup
#25 11.14     return run_commands(dist)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
#25 11.14     dist.run_commands()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
#25 11.14     self.run_command(cmd)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command
#25 11.14     super().run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#25 11.14     cmd_obj.run()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/install.py", line 80, in run
#25 11.14     self.do_egg_install()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/install.py", line 129, in do_egg_install
#25 11.14     self.run_command('bdist_egg')
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
#25 11.14     self.distribution.run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command
#25 11.14     super().run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#25 11.14     cmd_obj.run()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/bdist_egg.py", line 164, in run
#25 11.14     cmd = self.call_command('install_lib', warn_dir=0)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/bdist_egg.py", line 150, in call_command
#25 11.14     self.run_command(cmdname)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
#25 11.14     self.distribution.run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command
#25 11.14     super().run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#25 11.14     cmd_obj.run()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/install_lib.py", line 11, in run
#25 11.14     self.build()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/command/install_lib.py", line 111, in build
#25 11.14     self.run_command('build_ext')
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
#25 11.14     self.distribution.run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/dist.py", line 1234, in run_command
#25 11.14     super().run_command(command)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#25 11.14     cmd_obj.run()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/build_ext.py", line 84, in run
#25 11.14     _build_ext.run(self)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 345, in run
#25 11.14     self.build_extensions()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 765, in build_extensions
#25 11.14     build_ext.build_extensions(self)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 467, in build_extensions
#25 11.14     self._build_extensions_serial()
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 493, in _build_extensions_serial
#25 11.14     self.build_extension(ext)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/command/build_ext.py", line 246, in build_extension
#25 11.14     _build_ext.build_extension(self, ext)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/Cython/Distutils/build_ext.py", line 127, in build_extension
#25 11.14     super(build_ext, self).build_extension(ext)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 548, in build_extension
#25 11.14     objects = self.compiler.compile(
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/setuptools/_distutils/ccompiler.py", line 600, in compile
#25 11.14     self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 513, in unix_wrap_single_compile
#25 11.14     cflags = unix_cuda_flags(cflags)
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 480, in unix_cuda_flags
#25 11.14     cflags + _get_cuda_arch_flags(cflags))
#25 11.14   File "/home/docker/.pyenv/versions/3.8.4/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 1694, in _get_cuda_arch_flags
#25 11.14     arch_list[-1] += '+PTX'
#25 11.14 IndexError: list index out of range
------
failed to solve: rpc error: code = Unknown desc = process "/bin/sh -c python /tmp/nms/setup.py install" did not complete successfully: exit code: 1
```

This allows each developer to change the specification according to the Arch of GPU they have.

```dockerfile
ARG TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6
```