### PR TITLE
Training and testing on MMDetection3.3 environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ The official implementation of [our paper](https://openaccess.thecvf.com/content
 
 ## What's New
 
-- **Draft branches under development: [[mmdet3x env](https://github.com/hirotomusiker/CLRerNet/tree/feature/mmv3_env)] (only test and demo inference) [[CurveLanes dataset](https://github.com/hirotomusiker/CLRerNet/tree/feature/curvelanes)] (train, test)**
+- **Draft branches under development: [[CurveLanes dataset](https://github.com/hirotomusiker/CLRerNet/tree/feature/curvelanes)] **
+- **[v0.3.0 release](https://github.com/hirotomusiker/CLRerNet/tree/v0.3.0) supports mmdet3x environment!**
 - Code for training is available ! (Dec. 1, 2023)
 - Our CLRerNet paper has been accepted to WACV2024 ! (Oct. 25, 2023)
 - LaneIoU loss and cost are published. ([PR#17](https://github.com/hirotomusiker/CLRerNet/pull/17), Oct.22, 2023)
@@ -34,6 +35,9 @@ CLRNet        | DLA34    | 80.47  | 18.4
 \* F1 score stats of five models reported in our paper. The release models' scores are 81.11 (CLRerNet) and 81.55 (CLRerNet&#8902;, EMA model) respectively.
 
 ## Install
+
+This repo is now based on the [mmdetection 3.3](https://github.com/open-mmlab/mmdetection/tree/v3.3.0) environment.  
+If you prefer the previous mmdet2x-based CLRerNet, please checkout the [v0.2.1 branch](https://github.com/hirotomusiker/CLRerNet/tree/v0.2.1).  
 
 Docker environment is recommended for installation:
 ```bash
@@ -91,11 +95,12 @@ python tools/speed_test.py configs/clrernet/culane/clrernet_culane_dla34.py clre
 ## Citation
 
 ```BibTeX
-@article{honda2023clrernet,
-      title={CLRerNet: Improving Confidence of Lane Detection with LaneIoU},
-      author={Hiroto Honda and Yusuke Uchida},
-      journal={arXiv preprint arXiv:2305.08366},
-      year={2023},
+@inproceedings{honda2024clrernet,
+  title={Clrernet: improving confidence of lane detection with laneiou},
+  author={Honda, Hiroto and Uchida, Yusuke},
+  booktitle={Proceedings of the IEEE/CVF winter conference on applications of computer vision},
+  pages={1176--1185},
+  year={2024}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ If you prefer the previous mmdet2x-based CLRerNet, please checkout the [v0.2.1 b
 
 Docker environment is recommended for installation:
 ```bash
-docker-compose build --build-arg UID="`id -u`" dev
-docker-compose run --rm dev
+docker compose build --build-arg UID="`id -u`" dev
+docker compose run --rm dev
 ```
 
 See [Installation Tips](docs/INSTALL.md) for more details.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official implementation of [our paper](https://openaccess.thecvf.com/content
 
 ## What's New
 
-- **Draft branches under development: [[CurveLanes dataset](https://github.com/hirotomusiker/CLRerNet/tree/feature/curvelanes)] **
+- **Draft branches under development: [[CurveLanes dataset](https://github.com/hirotomusiker/CLRerNet/tree/feature/curvelanes)]**
 - **[v0.3.0 release](https://github.com/hirotomusiker/CLRerNet/tree/v0.3.0) supports mmdet3x environment!**
 - Code for training is available ! (Dec. 1, 2023)
 - Our CLRerNet paper has been accepted to WACV2024 ! (Oct. 25, 2023)

--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -1,17 +1,26 @@
 # runtime settings
-checkpoint_config = dict(interval=10)
+# Adapted from:
+# https://github.com/open-mmlab/mmdetection/blob/v3.3.0/configs/_base_/default_runtime.py
 
-log_config = dict(
-    interval=100,
-    hooks=[
-        dict(type='TextLoggerHook'),
-    ],
+default_hooks = dict(
+    timer=dict(type='IterTimerHook'),
+    logger=dict(type='LoggerHook', interval=100),
+    param_scheduler=dict(type='ParamSchedulerHook'),
+    checkpoint=dict(type='CheckpointHook', interval=10),
+    sampler_seed=dict(type='DistSamplerSeedHook'),
+    visualization=dict(type='DetVisualizationHook'))
+
+env_cfg = dict(
+    cudnn_benchmark=False,
+    mp_cfg=dict(mp_start_method='fork', opencv_num_threads=0),
+    dist_cfg=dict(backend='nccl'),
 )
 
-device_ids = "0"
-dist_params = dict(backend='nccl')
+vis_backends = [dict(type='LocalVisBackend')]
+visualizer = dict(
+    type='DetLocalVisualizer', vis_backends=vis_backends, name='visualizer')
+log_processor = dict(type='LogProcessor', window_size=50, by_epoch=True)
+
 log_level = 'INFO'
 load_from = None
-resume_from = None
-workflow = [('train', 1)]
-evaluation = dict(interval=1, metric='F1')
+resume = False

--- a/configs/clrernet/base_clrernet.py
+++ b/configs/clrernet/base_clrernet.py
@@ -39,12 +39,12 @@ model = dict(
             lane_width=7.5 / 800,
             loss_weight=4.0,
         ),
-        # switched from CLRNetSegLoss for deterministic training
         loss_seg=dict(
-            type="CrossEntropyLoss",
+            type="CLRNetSegLoss",
             loss_weight=1.0,
-            ignore_index=255,
-            class_weight=[0.4, 1, 1, 1, 1],
+            num_classes=5,  # 4 lanes + 1 background
+            ignore_label=255,
+            bg_weight=0.4,
         ),
     ),
     # training and testing settings

--- a/configs/clrernet/base_clrernet.py
+++ b/configs/clrernet/base_clrernet.py
@@ -39,12 +39,12 @@ model = dict(
             lane_width=7.5 / 800,
             loss_weight=4.0,
         ),
+        # switched from CLRNetSegLoss for deterministic training
         loss_seg=dict(
-            type="CLRNetSegLoss",
+            type="CrossEntropyLoss",
             loss_weight=1.0,
-            num_classes=5,  # 4 lanes + 1 background
-            ignore_label=255,
-            bg_weight=0.4,
+            ignore_index=255,
+            class_weight=[0.4, 1, 1, 1, 1],
         ),
     ),
     # training and testing settings

--- a/configs/clrernet/base_clrernet.py
+++ b/configs/clrernet/base_clrernet.py
@@ -77,6 +77,7 @@ model = dict(
         conf_threshold=0.41,
         use_nms=True,
         as_lanes=True,
+        extend_bottom=True,
         nms_thres=50,
         nms_topk=4,
         ori_img_w=1640,

--- a/configs/clrernet/base_clrernet.py
+++ b/configs/clrernet/base_clrernet.py
@@ -1,5 +1,11 @@
 model = dict(
     type="CLRerNet",
+    data_preprocessor=dict(
+        type='DetDataPreprocessor',
+        mean=[0, 0, 0],
+        std=[255.0, 255.0, 255.0],
+        bgr_to_rgb=False,
+        batch_augments=None),
     backbone=dict(
         type="DLANet",
         dla="dla34",

--- a/configs/clrernet/culane/clrernet_culane_dla34.py
+++ b/configs/clrernet/culane/clrernet_culane_dla34.py
@@ -41,9 +41,19 @@ optim_wrapper = dict(
     optimizer=dict(type="AdamW", lr=6e-4),
 )
 
+# learning rate policy
+param_scheduler = [
+    dict(
+        type='CosineAnnealingLR',
+        eta_min=0,
+        begin=0,
+        T_max=total_epochs,
+        end=total_epochs,
+        by_epoch=True,
+        convert_to_iter_based=True
+        ),
+]
 
-# learning policy
-lr_config = dict(policy="CosineAnnealing", min_lr=0.0, by_epoch=False)
 
 log_config = dict(
     hooks=[

--- a/configs/clrernet/culane/clrernet_culane_dla34.py
+++ b/configs/clrernet/culane/clrernet_culane_dla34.py
@@ -3,6 +3,7 @@ _base_ = [
     "dataset_culane_clrernet.py",
     "../../_base_/default_runtime.py",
 ]
+default_scope = 'mmdet'
 
 # custom imports
 custom_imports = dict(
@@ -21,14 +22,20 @@ cfg_name = "clrernet_culane_dla34.py"
 model = dict(test_cfg=dict(conf_threshold=0.41))
 
 total_epochs = 15
-evaluation = dict(interval=3)
 checkpoint_config = dict(interval=total_epochs)
+
+train_cfg = dict(max_epochs=total_epochs, val_interval=3)
+val_cfg = dict(type='ValLoop')
+test_cfg = dict(type='TestLoop')
 
 data = dict(samples_per_gpu=24)  # single GPU setting
 
 # optimizer
-optimizer = dict(type="AdamW", lr=6e-4)
-optimizer_config = dict(grad_clip=None)
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(type="AdamW", lr=6e-4),
+)
+
 
 # learning policy
 lr_config = dict(policy="CosineAnnealing", min_lr=0.0, by_epoch=False)

--- a/configs/clrernet/culane/clrernet_culane_dla34.py
+++ b/configs/clrernet/culane/clrernet_culane_dla34.py
@@ -24,11 +24,16 @@ model = dict(test_cfg=dict(conf_threshold=0.41))
 total_epochs = 15
 checkpoint_config = dict(interval=total_epochs)
 
-train_cfg = dict(max_epochs=total_epochs, val_interval=3)
+train_cfg = dict(type='EpochBasedTrainLoop', max_epochs=total_epochs, val_interval=3)
 val_cfg = dict(type='ValLoop')
 test_cfg = dict(type='TestLoop')
 
-data = dict(samples_per_gpu=24)  # single GPU setting
+train_dataloader=dict(
+    batch_size=24
+ ) # single GPU setting
+
+# seed
+randomness = dict(seed=0, deterministic=True)
 
 # optimizer
 optim_wrapper = dict(

--- a/configs/clrernet/culane/clrernet_culane_dla34_ema.py
+++ b/configs/clrernet/culane/clrernet_culane_dla34_ema.py
@@ -3,6 +3,7 @@ _base_ = [
     "dataset_culane_clrernet.py",
     "../../_base_/default_runtime.py",
 ]
+default_scope = 'mmdet'
 
 # custom imports
 custom_imports = dict(
@@ -20,25 +21,29 @@ cfg_name = "clrernet_culane_dla34_ema.py"
 
 model = dict(test_cfg=dict(conf_threshold=0.43))
 
-
 custom_hooks = [dict(type="ExpMomentumEMAHook", momentum=0.0001, priority=49)]
 
 total_epochs = 50
-evaluation = dict(interval=total_epochs)
 checkpoint_config = dict(interval=total_epochs)
 
-data = dict(samples_per_gpu=24)  # single GPU setting
+train_cfg = dict(type='EpochBasedTrainLoop', max_epochs=total_epochs, val_interval=)
+val_cfg = dict(type='ValLoop')
+test_cfg = dict(type='TestLoop')
+
+train_dataloader=dict(
+    batch_size=24
+ ) # single GPU setting
+
+# seed
+randomness = dict(seed=0, deterministic=True)
 
 # optimizer
-optimizer = dict(type="AdamW", lr=6e-4)
-optimizer_config = dict(grad_clip=None)
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(type="AdamW", lr=6e-4),
+)
+
 
 # learning policy
-lr_config = dict(policy="CosineAnnealing", min_lr=6e-4, by_epoch=False)
+lr_config = dict(policy="CosineAnnealing", min_lr=0.0, by_epoch=False)
 
-log_config = dict(
-    hooks=[
-        dict(type="TextLoggerHook"),
-        dict(type="TensorboardLoggerHookEpoch"),
-    ]
-)

--- a/configs/clrernet/culane/clrernet_culane_dla34_ema.py
+++ b/configs/clrernet/culane/clrernet_culane_dla34_ema.py
@@ -45,5 +45,5 @@ optim_wrapper = dict(
 
 
 # learning policy
-lr_config = dict(policy="CosineAnnealing", min_lr=0.0, by_epoch=False)
+lr_config = dict(policy="CosineAnnealing", min_lr=6e-4, by_epoch=False)
 

--- a/configs/clrernet/culane/clrernet_culane_dla34_ema.py
+++ b/configs/clrernet/culane/clrernet_culane_dla34_ema.py
@@ -21,12 +21,19 @@ cfg_name = "clrernet_culane_dla34_ema.py"
 
 model = dict(test_cfg=dict(conf_threshold=0.43))
 
-custom_hooks = [dict(type="ExpMomentumEMAHook", momentum=0.0001, priority=49)]
+custom_hooks = [
+    dict(
+        type='EMAHook',
+        ema_type='ExpMomentumEMA',
+        momentum=0.0001,
+        update_buffers=True,
+        priority=49)
+]
 
 total_epochs = 50
 checkpoint_config = dict(interval=total_epochs)
 
-train_cfg = dict(type='EpochBasedTrainLoop', max_epochs=total_epochs, val_interval=)
+train_cfg = dict(type='EpochBasedTrainLoop', max_epochs=total_epochs, val_interval=10)
 val_cfg = dict(type='ValLoop')
 test_cfg = dict(type='TestLoop')
 

--- a/configs/clrernet/culane/dataset_culane_clrernet.py
+++ b/configs/clrernet/culane/dataset_culane_clrernet.py
@@ -66,17 +66,15 @@ val_al_pipeline = [
 
 train_pipeline = [
     dict(type="albumentation", pipelines=train_al_pipeline),
-    dict(type="Normalize", **img_norm_cfg),
-    dict(type="DefaultFormatBundle"),
+    #dict(type="Normalize", **img_norm_cfg),
     dict(
-        type="CollectCLRNet",
-        keys=["img"],
+        type="PackCLRNetInputs",
+        #keys=["img"],
         meta_keys=[
             "filename",
             "sub_img_name",
             "ori_shape",
             "img_shape",
-            "img_norm_cfg",
             "ori_shape",
             "img_shape",
             "gt_points",
@@ -88,26 +86,25 @@ train_pipeline = [
 
 val_pipeline = [
     dict(type="albumentation", pipelines=val_al_pipeline),
-    dict(type="Normalize", **img_norm_cfg),
-    dict(type="DefaultFormatBundle"),
+    #dict(type="Normalize", **img_norm_cfg),
     dict(
-        type="CollectCLRNet",
-        keys=["img"],
+        type="PackCLRNetInputs",
+        #keys=["img"],
         meta_keys=[
             "filename",
             "sub_img_name",
             "ori_shape",
             "img_shape",
-            "img_norm_cfg",
         ],
     ),
 ]
 
 
-data = dict(
-    samples_per_gpu=32,  # medium
-    workers_per_gpu=8,
-    train=dict(
+train_dataloader=dict(
+    batch_size=32,
+    num_workers=4,
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    dataset=dict(
         type=dataset_type,
         data_root=data_root,
         data_list=data_root + "/list/train_gt.txt",
@@ -115,15 +112,27 @@ data = dict(
         diff_thr=15,
         pipeline=train_pipeline,
         test_mode=False,
-    ),
-    val=dict(
+    )
+)
+val_dataloader=dict(
+    batch_size=16,
+    num_workers=4,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
         type=dataset_type,
         data_root=data_root,
-        data_list=data_root + "/list/test.txt",
+        data_list=data_root + "/list/val.txt",
         pipeline=val_pipeline,
         test_mode=True,
     ),
-    test=dict(
+)
+test_dataloader=dict(
+    batch_size=16,
+    num_workers=4,
+    drop_last=False,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    dataset=dict(
         type=dataset_type,
         data_root=data_root,
         data_list=data_root + "/list/test.txt",

--- a/configs/clrernet/culane/dataset_culane_clrernet.py
+++ b/configs/clrernet/culane/dataset_culane_clrernet.py
@@ -115,7 +115,7 @@ train_dataloader=dict(
     )
 )
 val_dataloader=dict(
-    batch_size=16,
+    batch_size=64,
     num_workers=4,
     drop_last=False,
     sampler=dict(type='DefaultSampler', shuffle=False),
@@ -128,7 +128,7 @@ val_dataloader=dict(
     ),
 )
 test_dataloader=dict(
-    batch_size=16,
+    batch_size=64,
     num_workers=4,
     drop_last=False,
     sampler=dict(type='DefaultSampler', shuffle=False),
@@ -140,3 +140,10 @@ test_dataloader=dict(
         test_mode=True,
     ),
 )
+
+val_evaluator = dict(
+    type='CULaneMetric',
+    data_root=data_root,
+    data_list=data_root + "/list/test.txt",
+    )
+test_evaluator = val_evaluator

--- a/configs/clrernet/culane/dataset_culane_clrernet.py
+++ b/configs/clrernet/culane/dataset_culane_clrernet.py
@@ -144,6 +144,11 @@ test_dataloader=dict(
 val_evaluator = dict(
     type='CULaneMetric',
     data_root=data_root,
+    data_list=data_root + "/list/val.txt",
+    )
+
+test_evaluator = dict(
+    type='CULaneMetric',
+    data_root=data_root,
     data_list=data_root + "/list/test.txt",
     )
-test_evaluator = val_evaluator

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,19 @@
 version: "2.3"
 services:
-  dev:
+  mmdet3x:
     runtime: nvidia
     build:
       context: .
       dockerfile: ./docker/Dockerfile
       args:
-        PYTHON_VERSION: 3.8.4
-        TORCH_VERSION: 1.12.1+cu116
-        TORCHVISION_VERSION: 0.13.1
-        TORCH_CUDA_ARCH_LIST: 7.5;8.0;8.6
-        MIM_VERSION: 0.3.3
-        MMCV_VERSION: 1.7.0
-        MMDET_VERSION: 2.28.0
+        PYTHON_VERSION: 3.11.9
+        TORCH_VERSION: 2.1.0
+        TORCHVISION_VERSION: 0.16.0
+        TORCH_CUDA_ARCH_LIST: 7.5;8.0;8.6;9.0
+        MIM_VERSION: 0.3.9
+        MMCV_VERSION: 2.1.0
+        MMDET_VERSION: 3.3.0
+        MMENGINE_VERSION: 0.10.5
     shm_size: "16gb"
     tty: true
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,5 @@
-version: "2.3"
 services:
-  mmdet3x:
+  dev:
     runtime: nvidia
     build:
       context: .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,9 @@ COPY --chown=docker libs/models/layers/nms /tmp/nms
 WORKDIR /tmp/nms
 RUN python /tmp/nms/setup.py install
 
+# enable deterministic training
+ENV CUBLAS_WORKSPACE_CONFIG=:4096:8
+
 # path
 ENV PYTHONPATH $PYTHONPATH:/work
 ENV PYTHONPATH $PYTHONPATH:/home/docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
 
 # packages
 RUN apt-get update && \
@@ -27,23 +27,19 @@ RUN pyenv install ${PYTHON_VERSION} && pyenv global ${PYTHON_VERSION}
 ARG TORCH_VERSION
 ARG TORCH_CUDA_ARCH_LIST
 ARG TORCHVISION_VERSION
-RUN pip install torch==${TORCH_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install "numpy<2.0"
+RUN pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/cu121
 RUN pip install torchvision==${TORCHVISION_VERSION}
 
 # mmcv
 ARG MIM_VERSION
 ARG MMCV_VERSION
-RUN pip install -U openmim==${MIM_VERSION}
-RUN mim install mmcv-full==${MMCV_VERSION}
-
-# mmdet
+ARG MMENGINE_VERSION
 ARG MMDET_VERSION
-WORKDIR /home/docker/
-RUN pip install Cython
-RUN git clone https://github.com/open-mmlab/mmdetection.git mmdetection -b v${MMDET_VERSION} --depth 1
-WORKDIR /home/docker/mmdetection
-ENV FORCE_CUDA="1"
-RUN pip install --no-cache-dir -e .
+RUN pip install -U openmim==${MIM_VERSION}
+RUN mim install mmcv==${MMCV_VERSION}
+RUN mim install mmengine==${MMENGINE_VERSION}
+RUN mim install mmdet==${MMDET_VERSION}
 
 # requirements
 RUN pip install -U pip setuptools

--- a/libs/api/inference.py
+++ b/libs/api/inference.py
@@ -4,10 +4,9 @@
 
 import cv2
 import torch
-from mmengine.dataset import default_collate
 
-from libs.datasets.pipelines import Compose
 from libs.datasets.metrics.culane_metric import interp
+from libs.datasets.pipelines import Compose
 
 
 def inference_one_image(model, img_path):
@@ -34,7 +33,6 @@ def inference_one_image(model, img_path):
 
     cfg = model.cfg
     model.bbox_head.test_cfg.as_lanes = False
-    device = next(model.parameters()).device  # model device
 
     test_pipeline = Compose(cfg.test_dataloader.dataset.pipeline)
 

--- a/libs/api/inference.py
+++ b/libs/api/inference.py
@@ -48,7 +48,7 @@ def inference_one_image(model, img_path):
     with torch.no_grad():
         results = model.test_step(data_)
 
-    lanes = results[0]['result']['lanes']
+    lanes = results[0]['lanes']
     preds = get_prediction(lanes, ori_shape[0], ori_shape[1])
 
     return img, preds

--- a/libs/core/anchor/__init__.py
+++ b/libs/core/anchor/__init__.py
@@ -1,1 +1,1 @@
-from .anchor_generator import CLRerNetAnchorGenerator
+from .anchor_generator import CLRerNetAnchorGenerator  # noqa: F401

--- a/libs/core/anchor/anchor_generator.py
+++ b/libs/core/anchor/anchor_generator.py
@@ -1,10 +1,10 @@
 import numpy as np
 import torch
-from mmdet.core.anchor.builder import PRIOR_GENERATORS
+from mmdet.registry import TASK_UTILS
 from torch import nn
 
 
-@PRIOR_GENERATORS.register_module()
+@TASK_UTILS.register_module()
 class CLRerNetAnchorGenerator(nn.Module):
     """
     Anchor (prior) generator.

--- a/libs/core/bbox/__init__.py
+++ b/libs/core/bbox/__init__.py
@@ -1,2 +1,3 @@
 from .assigners.dynamic_topk_assigner import DynamicTopkAssigner  # noqa: F401
-from .match_costs.match_cost import CLRNetIoUCost, LaneIoUCost  # noqa: F401
+from .match_costs.match_cost import CLRNetIoUCost  # noqa: F401
+from .match_costs.match_cost import LaneIoUCost  # noqa: F401

--- a/libs/core/bbox/assigners/dynamic_topk_assigner.py
+++ b/libs/core/bbox/assigners/dynamic_topk_assigner.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
-from mmdet.core.bbox.assigners.base_assigner import BaseAssigner
-from mmdet.core.bbox.builder import BBOX_ASSIGNERS
-from mmdet.core.bbox.match_costs import build_match_cost
+from mmdet.models.task_modules.assigners.base_assigner import BaseAssigner
+from mmdet.registry import TASK_UTILS
 
 
-@BBOX_ASSIGNERS.register_module()
+@TASK_UTILS.register_module()
 class DynamicTopkAssigner(BaseAssigner):
     """Computes dynamick-to-one lane matching between predictions and ground truth (GT).
     The dynamic k for each GT is computed using Lane(Line)IoU matrix.
@@ -41,10 +40,10 @@ class DynamicTopkAssigner(BaseAssigner):
         max_topk=4,
         min_topk=1,
     ):
-        self.cls_cost = build_match_cost(cls_cost)
-        self.reg_cost = build_match_cost(reg_cost)
-        self.iou_dynamick = build_match_cost(iou_dynamick)
-        self.iou_cost = build_match_cost(iou_cost)
+        self.cls_cost = TASK_UTILS.build(cls_cost)
+        self.reg_cost = TASK_UTILS.build(reg_cost)
+        self.iou_dynamick = TASK_UTILS.build(iou_dynamick)
+        self.iou_cost = TASK_UTILS.build(iou_cost)
         self.use_pred_length_for_iou = use_pred_length_for_iou
         self.max_topk = max_topk
         self.min_topk = min_topk

--- a/libs/core/bbox/assigners/dynamic_topk_assigner.py
+++ b/libs/core/bbox/assigners/dynamic_topk_assigner.py
@@ -200,7 +200,7 @@ class DynamicTopkAssigner(BaseAssigner):
             matched_col_inds (Tensor): matched targets, shape: (num_targets).
         Np: number of priors (anchors), Ng: number of GT lanes, Nr: number of rows.
         """
-        img_h, img_w, _ = img_meta["img_shape"]
+        img_h, img_w, _ = img_meta.img_shape
 
         pred_xs = predictions["xs"].detach().clone()  # relative
         target_xs = targets[:, 6:] / (img_w - 1)  # abs -> relative

--- a/libs/core/bbox/match_costs/__init__.py
+++ b/libs/core/bbox/match_costs/__init__.py
@@ -1,1 +1,2 @@
-from .match_cost import CLRNetIoUCost, LaneIoUCost  # noqa: F401
+from .match_cost import CLRNetIoUCost  # noqa: F401
+from .match_cost import LaneIoUCost  # noqa: F401

--- a/libs/core/bbox/match_costs/match_cost.py
+++ b/libs/core/bbox/match_costs/match_cost.py
@@ -1,10 +1,10 @@
 import torch
-from mmdet.core.bbox.match_costs.builder import MATCH_COST
+from mmdet.registry import TASK_UTILS
 
 from libs.models.losses import LaneIoULoss
 
 
-@MATCH_COST.register_module()
+@TASK_UTILS.register_module()
 class FocalCost:
     def __init__(self, weight=1.0, alpha=0.25, gamma=2, eps=1e-12):
         self.alpha = alpha
@@ -34,7 +34,7 @@ class FocalCost:
         return cls_cost * self.weight
 
 
-@MATCH_COST.register_module()
+@TASK_UTILS.register_module()
 class DistanceCost:
     def __init__(self, weight=1.0):
         self.weight = weight
@@ -67,7 +67,7 @@ class DistanceCost:
         return distances
 
 
-@MATCH_COST.register_module()
+@TASK_UTILS.register_module()
 class CLRNetIoUCost:
     def __init__(self, weight=1.0, lane_width=15 / 800):
         """
@@ -129,7 +129,7 @@ class CLRNetIoUCost:
         return iou * self.weight
 
 
-@MATCH_COST.register_module()
+@TASK_UTILS.register_module()
 class LaneIoUCost(CLRNetIoUCost, LaneIoULoss):
     def __init__(
         self,

--- a/libs/core/hook/logger.py
+++ b/libs/core/hook/logger.py
@@ -1,11 +1,9 @@
-from mmcv.runner.dist_utils import master_only
-from mmcv.runner.hooks import HOOKS
-from mmcv.runner.hooks.logger.tensorboard import TensorboardLoggerHook
+from mmengine.registry import VISBACKENDS
+from mmengine.visualization.vis_backend import TensorboardVisBackend
 
 
-@HOOKS.register_module()
-class TensorboardLoggerHookEpoch(TensorboardLoggerHook):
-    @master_only
+@VISBACKENDS.register_module()
+class TensorboardLoggerHookEpoch(TensorboardVisBackend):
     def log(self, runner):
         tags = self.get_loggable_tags(runner, allow_text=True)
         for tag, val in tags.items():

--- a/libs/datasets/__init__.py
+++ b/libs/datasets/__init__.py
@@ -1,2 +1,4 @@
-from .culane_dataset import CulaneDataset
-from .pipelines import Compose, PackCLRNetInputs
+from .culane_dataset import CulaneDataset  # noqa: F401
+from .metrics.culane_metric import CULaneMetric  # noqa: F401
+from .pipelines import Compose  # noqa: F401
+from .pipelines import PackCLRNetInputs  # noqa: F401

--- a/libs/datasets/__init__.py
+++ b/libs/datasets/__init__.py
@@ -1,2 +1,2 @@
 from .culane_dataset import CulaneDataset
-from .pipelines import Compose, CollectCLRNet
+from .pipelines import Compose, PackCLRNetInputs

--- a/libs/datasets/culane_dataset.py
+++ b/libs/datasets/culane_dataset.py
@@ -56,7 +56,7 @@ class CulaneDataset(Dataset):
             data_list
         )
         self.img_infos = self.img_infos
-        self._metainfo = {}
+        self.metainfo = {}
         print(len(self.img_infos), "data are loaded")
         # set group flag for the sampler
         if not self.test_mode:

--- a/libs/datasets/culane_dataset.py
+++ b/libs/datasets/culane_dataset.py
@@ -9,17 +9,17 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-from mmdet.datasets.builder import DATASETS
-from mmdet.datasets.custom import CustomDataset
-from mmdet.utils import get_root_logger
+from mmdet.registry import DATASETS
+from mmdet.datasets.base_det_dataset import BaseDetDataset
+from mmengine.logging import MMLogger
 from tqdm import tqdm
 
 from libs.datasets.metrics.culane_metric import eval_predictions
 from libs.datasets.pipelines import Compose
 
 
-@DATASETS.register_module
-class CulaneDataset(CustomDataset):
+@DATASETS.register_module()
+class CulaneDataset(BaseDetDataset):
     """Culane Dataset class."""
 
     def __init__(
@@ -31,6 +31,7 @@ class CulaneDataset(CustomDataset):
         diff_thr=15,
         test_mode=True,
         y_step=2,
+        **kwargs
     ):
         """
         Args:
@@ -53,6 +54,7 @@ class CulaneDataset(CustomDataset):
         self.img_infos, self.annotations, self.mask_paths = self.parse_datalist(
             data_list
         )
+        self._metainfo = {}
         print(len(self.img_infos), "data are loaded")
         # set group flag for the sampler
         if not self.test_mode:
@@ -224,7 +226,7 @@ class CulaneDataset(CustomDataset):
             self.img_prefix,
             self.list_path,
             self.test_categories_dir,
-            logger=get_root_logger(log_level="INFO"),
+            logger=MMLogger.get_current_instance(),
         )
         shutil.rmtree(self.result_dir)
         return results

--- a/libs/datasets/culane_dataset.py
+++ b/libs/datasets/culane_dataset.py
@@ -3,20 +3,13 @@ Adapted from:
 https://github.com/aliyun/conditional-lane-detection/blob/master/mmdet/datasets/culane_dataset.py
 https://github.com/open-mmlab/mmengine/blob/v0.10.4/mmengine/dataset/base_dataset.py
 """
-
-
 from pathlib import Path
 
 import cv2
 import numpy as np
 from mmdet.registry import DATASETS
-from mmdet.datasets.base_det_dataset import BaseDetDataset
-from mmengine.logging import MMLogger
-from tqdm import tqdm
-
-from mmengine.dataset import BaseDataset
 from torch.utils.data import Dataset
-from libs.datasets.metrics.culane_metric import eval_predictions
+
 from libs.datasets.pipelines import Compose
 
 

--- a/libs/datasets/culane_dataset.py
+++ b/libs/datasets/culane_dataset.py
@@ -1,6 +1,7 @@
 """
 Adapted from:
 https://github.com/aliyun/conditional-lane-detection/blob/master/mmdet/datasets/culane_dataset.py
+https://github.com/open-mmlab/mmengine/blob/v0.10.4/mmengine/dataset/base_dataset.py
 """
 
 
@@ -14,12 +15,14 @@ from mmdet.datasets.base_det_dataset import BaseDetDataset
 from mmengine.logging import MMLogger
 from tqdm import tqdm
 
+from mmengine.dataset import BaseDataset
+from torch.utils.data import Dataset
 from libs.datasets.metrics.culane_metric import eval_predictions
 from libs.datasets.pipelines import Compose
 
 
 @DATASETS.register_module()
-class CulaneDataset(BaseDetDataset):
+class CulaneDataset(Dataset):
     """Culane Dataset class."""
 
     def __init__(
@@ -47,13 +50,13 @@ class CulaneDataset(BaseDetDataset):
 
         self.img_prefix = data_root
         self.test_mode = test_mode
-        self.ori_w, self.ori_h = 1640, 590
         # read image list
         self.diffs = np.load(diff_file)["data"] if diff_file is not None else []
         self.diff_thr = diff_thr
         self.img_infos, self.annotations, self.mask_paths = self.parse_datalist(
             data_list
         )
+        self.img_infos = self.img_infos
         self._metainfo = {}
         print(len(self.img_infos), "data are loaded")
         # set group flag for the sampler
@@ -62,10 +65,7 @@ class CulaneDataset(BaseDetDataset):
 
         # build data pipeline
         self.pipeline = Compose(pipeline)
-        self.result_dir = "tmp"
         self.list_path = data_list
-        self.test_categories_dir = str(Path(data_root).joinpath("list/test_split/"))
-        self.y_step = y_step
 
     def parse_datalist(self, data_list):
         """
@@ -194,65 +194,27 @@ class CulaneDataset(BaseDetDataset):
         id_instances = [i + 1 for i in range(len(shapes))]
         return shapes, id_classes, id_instances
 
-    def evaluate(self, results, metric="F1", logger=None):
-        """
-        Write prediction to txt files for evaluation and
-        evaluate them with labels.
+    def _rand_another(self, idx):
+        """Get another random index from the same group as the given index."""
+        pool = np.where(self.flag == self.flag[idx])[0]
+        return np.random.choice(pool)
+
+    def __getitem__(self, idx):
+        """Get training/test data after pipeline.
+
         Args:
-            results (List[dict]): All inference results containing:
-                result (dict): contains 'lanes' and 'scores'.
-                meta (dict): contains meta information.
-            metric (str): Metric type to evaluate. (not used)
+            idx (int): Index of data.
+
         Returns:
-            dict: Evaluation result dict containing
-                F1, precision, recall, etc. on the specified IoU thresholds.
-
+            dict: Training/test data (with annotation if `test_mode` is set \
+                True).
         """
-        for result in tqdm(results):
-            lanes = result["result"]["lanes"]
-            dst_path = (
-                Path(self.result_dir)
-                .joinpath(result["meta"]["sub_img_name"])
-                .with_suffix(".lines.txt")
-            )
-            dst_path.parents[0].mkdir(parents=True, exist_ok=True)
-            with open(str(dst_path), "w") as f:
-                output = self.get_prediction_string(lanes)
-                if len(output) > 0:
-                    print(output, file=f)
 
-        results = eval_predictions(
-            self.result_dir,
-            self.img_prefix,
-            self.list_path,
-            self.test_categories_dir,
-            logger=MMLogger.get_current_instance(),
-        )
-        shutil.rmtree(self.result_dir)
-        return results
-
-    def get_prediction_string(self, lanes):
-        """
-        Convert lane instance structure to prediction strings.
-        Args:
-            lanes (List[Lane]): List of lane instances in `Lane` structure.
-        Returns:
-            out_string (str): Output string.
-        """
-        ys = np.arange(0, self.ori_h, self.y_step) / self.ori_h
-        out = []
-        for lane in lanes:
-            xs = lane(ys)
-            valid_mask = (xs >= 0) & (xs < 1)
-            xs = xs * self.ori_w
-            lane_xs = xs[valid_mask]
-            lane_ys = ys[valid_mask] * self.ori_h
-            lane_xs, lane_ys = lane_xs[::-1], lane_ys[::-1]
-            if len(lane_xs) < 2:
+        if self.test_mode:
+            return self.prepare_test_img(idx)
+        while True:
+            data = self.prepare_train_img(idx)
+            if data is None:
+                idx = self._rand_another(idx)
                 continue
-            lane_str = " ".join(
-                ["{:.5f} {:.5f}".format(x, y) for x, y in zip(lane_xs, lane_ys)]
-            )
-            if lane_str != "":
-                out.append(lane_str)
-        return "\n".join(out) if len(out) > 0 else ""
+            return data

--- a/libs/datasets/metrics/culane_metric.py
+++ b/libs/datasets/metrics/culane_metric.py
@@ -8,20 +8,22 @@ import os
 from pathlib import Path
 from functools import partial
 import tempfile
+from functools import partial
+from pathlib import Path
 from typing import Sequence
 
 import numpy as np
-from tqdm import tqdm
-from p_tqdm import t_map, p_map
-from scipy.optimize import linear_sum_assignment
-
 from mmdet.registry import METRICS
 from mmengine.evaluator import BaseMetric
-from mmengine.logging import print_log
 from mmengine.logging import MMLogger
-
-from libs.utils.visualizer import draw_lane
+from mmengine.logging import print_log
+from p_tqdm import p_map
+from p_tqdm import t_map
+from scipy.optimize import linear_sum_assignment
+from tqdm import tqdm
+ 
 from libs.utils.lane_utils import interp
+from libs.utils.visualizer import draw_lane
 
 
 @METRICS.register_module()

--- a/libs/datasets/metrics/culane_metric.py
+++ b/libs/datasets/metrics/culane_metric.py
@@ -7,7 +7,8 @@ Copyright (c) 2021 Lucas Tabelini
 import os
 from pathlib import Path
 from functools import partial
-from typing import Dict, List, Optional, Sequence, Union
+import tempfile
+from typing import Sequence
 
 import numpy as np
 from tqdm import tqdm
@@ -29,7 +30,7 @@ class CULaneMetric(BaseMetric):
         self.img_prefix = data_root
         self.list_path = data_list
         self.test_categories_dir = str(Path(data_root).joinpath("list/test_split/"))
-        self.result_dir = "tmp"
+        self.result_dir = tempfile.TemporaryDirectory().name
         self.ori_w, self.ori_h = 1640, 590
         self.y_step = y_step
         super().__init__()

--- a/libs/datasets/metrics/culane_metric.py
+++ b/libs/datasets/metrics/culane_metric.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from p_tqdm import t_map, p_map
 from scipy.optimize import linear_sum_assignment
 
-from mmcv.utils import print_log
+from mmengine.logging import print_log
 
 from libs.utils.visualizer import draw_lane
 from libs.utils.lane_utils import interp

--- a/libs/datasets/pipelines/__init__.py
+++ b/libs/datasets/pipelines/__init__.py
@@ -1,3 +1,3 @@
-from .alaug import Alaug
-from .compose import Compose
-from .lane_formatting import PackCLRNetInputs
+from .alaug import Alaug  # noqa: F401
+from .compose import Compose  # noqa: F401
+from .lane_formatting import PackCLRNetInputs  # noqa: F401

--- a/libs/datasets/pipelines/__init__.py
+++ b/libs/datasets/pipelines/__init__.py
@@ -1,3 +1,3 @@
 from .alaug import Alaug
 from .compose import Compose
-from .lane_formatting import CollectCLRNet
+from .lane_formatting import PackCLRNetInputs

--- a/libs/datasets/pipelines/alaug.py
+++ b/libs/datasets/pipelines/alaug.py
@@ -10,10 +10,10 @@ import collections
 import albumentations as al
 import numpy as np
 
-from mmdet.datasets.builder import PIPELINES
+from mmdet.registry import TRANSFORMS
 
 
-@PIPELINES.register_module
+@TRANSFORMS.register_module()
 class Alaug(object):
     def __init__(self, transforms):
         assert isinstance(transforms, collections.abc.Sequence)

--- a/libs/datasets/pipelines/alaug.py
+++ b/libs/datasets/pipelines/alaug.py
@@ -4,12 +4,11 @@ Adapted from:
 https://github.com/aliyun/conditional-lane-detection/blob/master/mmdet/datasets/pipelines/alaug.py
 """
 
-import copy
 import collections
+import copy
 
 import albumentations as al
 import numpy as np
-
 from mmdet.registry import TRANSFORMS
 
 
@@ -139,7 +138,6 @@ class Alaug(object):
 
         if 'gt_points' in data:
             points = data["gt_points"]
-            p_group_num = len(points)
             # run aug
             points_index = []
             for k in points:

--- a/libs/datasets/pipelines/compose.py
+++ b/libs/datasets/pipelines/compose.py
@@ -5,13 +5,12 @@ https://github.com/aliyun/conditional-lane-detection/blob/master/mmdet/datasets/
 
 import collections
 
-from mmdet.datasets.builder import PIPELINES
-from mmcv.utils import build_from_cfg
+from mmdet.registry import TRANSFORMS
 
 from .alaug import Alaug
 
 
-@PIPELINES.register_module(force=True)
+@TRANSFORMS.register_module()
 class Compose(object):
     def __init__(self, transforms):
         assert isinstance(transforms, collections.abc.Sequence)
@@ -21,7 +20,7 @@ class Compose(object):
                 if transform['type'] == 'albumentation':
                     transform = Alaug(transform['pipelines'])
                 else:
-                    transform = build_from_cfg(transform, PIPELINES)
+                    transform = TRANSFORMS.build(transform)
                 self.transforms.append(transform)
             elif callable(transform):
                 self.transforms.append(transform)

--- a/libs/datasets/pipelines/lane_formatting.py
+++ b/libs/datasets/pipelines/lane_formatting.py
@@ -1,13 +1,11 @@
 import math
 
 import numpy as np
-#from mmcv.parallel import DataContainer as DC
-from mmcv.transforms.base import BaseTransform
 from mmcv.transforms import to_tensor
+from mmcv.transforms.base import BaseTransform
 from mmdet.registry import TRANSFORMS
 from mmdet.structures import DetDataSample
 from mmengine.structures import InstanceData
-#from mmdet.datasets.pipelines.formatting import Collect, to_tensor
 
 from libs.utils.lane_utils import sample_lane
 

--- a/libs/datasets/pipelines/lane_formatting.py
+++ b/libs/datasets/pipelines/lane_formatting.py
@@ -1,25 +1,29 @@
 import math
 
 import numpy as np
-from mmcv.parallel import DataContainer as DC
-from mmdet.datasets.builder import PIPELINES
-from mmdet.datasets.pipelines.formatting import Collect, to_tensor
+#from mmcv.parallel import DataContainer as DC
+from mmcv.transforms.base import BaseTransform
+from mmcv.transforms import to_tensor
+from mmdet.registry import TRANSFORMS
+from mmdet.structures import DetDataSample
+from mmengine.structures import InstanceData
+#from mmdet.datasets.pipelines.formatting import Collect, to_tensor
 
 from libs.utils.lane_utils import sample_lane
 
 
-@PIPELINES.register_module
-class CollectCLRNet(Collect):
+@TRANSFORMS.register_module()
+class PackCLRNetInputs(BaseTransform):
     def __init__(
         self,
-        keys=None,
+        #keys=None,
         meta_keys=None,
         max_lanes=4,
         num_points=72,
         img_w=800,
         img_h=320,
     ):
-        self.keys = keys
+        #self.keys = keys
         self.meta_keys = meta_keys
         self.max_lanes = max_lanes
         self.n_offsets = num_points
@@ -76,14 +80,20 @@ class CollectCLRNet(Collect):
         results["lanes"] = to_tensor(lanes)
         return results
 
-    def __call__(self, results):
+    def transform(self, results):
         data = {}
         img_meta = {}
+        data_sample = DetDataSample()
+        instance_data = InstanceData()
+        if "img" in results:
+            img = results["img"]
+            img = to_tensor(img).permute(2, 0, 1).contiguous()
         if "lanes" in self.meta_keys:  # training
             results = self.convert_targets(results)
         for key in self.meta_keys:
             img_meta[key] = results[key]
-        data["img_metas"] = DC(img_meta, cpu_only=True)
-        for key in self.keys:
-            data[key] = results[key]
+        data_sample.gt_instances = instance_data
+        data_sample.set_metainfo(img_meta)
+        data["data_samples"] = data_sample
+        data["inputs"] = img
         return data

--- a/libs/models/__init__.py
+++ b/libs/models/__init__.py
@@ -2,5 +2,7 @@ from .backbones import DLA  # noqa: F401
 from .dense_heads import CLRerHead  # noqa: F401
 from .detectors import CLRerNet  # noqa: F401
 from .layers import ROIGather  # noqa: F401
-from .losses import CLRNetSegLoss, KorniaFocalLoss, LaneIoULoss  # noqa: F401
+from .losses import CLRNetSegLoss  # noqa: F401
+from .losses import KorniaFocalLoss  # noqa: F401
+from .losses import LaneIoULoss  # noqa: F401
 from .necks import CLRerNetFPN  # noqa: F401

--- a/libs/models/backbones/dla.py
+++ b/libs/models/backbones/dla.py
@@ -3,18 +3,14 @@ Adapted from:
 https://github.com/Turoad/CLRNet/blob/main/clrnet/models/backbones/dla34.py
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import math
 import logging
+import math
 from os.path import join
 
 import torch
-from torch import nn
 import torch.utils.model_zoo as model_zoo
 from mmdet.registry import MODELS
+from torch import nn
 
 
 BN_MOMENTUM = 0.1

--- a/libs/models/backbones/dla.py
+++ b/libs/models/backbones/dla.py
@@ -14,7 +14,7 @@ from os.path import join
 import torch
 from torch import nn
 import torch.utils.model_zoo as model_zoo
-from mmdet.models.builder import BACKBONES
+from mmdet.registry import MODELS
 
 
 BN_MOMENTUM = 0.1
@@ -405,7 +405,7 @@ def dla34(pretrained=True, levels=None, in_channels=None, **kwargs):  # DLA-34
     return model
 
 
-@BACKBONES.register_module
+@MODELS.register_module()
 class DLANet(nn.Module):
     def __init__(
         self,

--- a/libs/models/dense_heads/clrernet_head.py
+++ b/libs/models/dense_heads/clrernet_head.py
@@ -2,18 +2,19 @@
 Adapted from:
 https://github.com/Turoad/CLRNet/blob/main/clrnet/models/heads/clr_head.py
 """
+from typing import Tuple
 
 import numpy as np
-from typing import Tuple
 import torch
-from torch import Tensor
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn.bricks.transformer import build_attention
-from mmdet.registry import MODELS, TASK_UTILS
-from mmdet.structures import SampleList
 from mmdet.models.dense_heads.base_dense_head import BaseDenseHead
+from mmdet.registry import MODELS
+from mmdet.registry import TASK_UTILS
+from mmdet.structures import SampleList
 from nms import nms
+from torch import Tensor
 
 from libs.models.dense_heads.seg_decoder import SegDecoder
 from libs.utils.lane_utils import Lane

--- a/libs/models/dense_heads/clrernet_head.py
+++ b/libs/models/dense_heads/clrernet_head.py
@@ -250,10 +250,7 @@ class CLRerHead(BaseDenseHead):
 
         return predictions_list
 
-    def loss_by_feat(self, **kwargs):
-        pass
-
-    def _loss(self, out_dict, batch_data_samples):
+    def loss_by_feat(self, out_dict, batch_data_samples):
         """Loss calculation from the network output.
 
         Args:
@@ -265,8 +262,8 @@ class CLRerHead(BaseDenseHead):
                 where
                 B: batch size, Np: number of priors (anchors), Nr: number of rows,
                 C: segmentation channels, H and W: the largest feature's spatial shape.
-            img_metas (list[dict]): Meta information of each image, e.g.,
-                image size, scaling factor, etc.
+            batch_data_samples: (List[:obj:`DetDataSample`]): The data samples
+                that include meta information.
         Returns:
             dict[str, Tensor]: A dictionary of loss components.
         """
@@ -363,8 +360,8 @@ class CLRerHead(BaseDenseHead):
         """Forward function for training mode.
         Args:
             x (list[Tensor]): Features from backbone.
-            img_metas (list[dict]): Meta information of each image, e.g.,
-                image size, scaling factor, etc.
+            batch_data_samples (List[:obj:`DetDataSample`]): The data samples
+                that include meta information.
         Returns:
             dict[str, Tensor]: A dictionary of loss components.
         """
@@ -373,7 +370,7 @@ class CLRerHead(BaseDenseHead):
         if self.loss_seg:
             out_dict["seg"] = self.forward_seg(x)
 
-        losses = self._loss(out_dict, batch_data_samples)
+        losses = self.loss_by_feat(out_dict, batch_data_samples)
         return losses
 
     def forward_seg(self, x):
@@ -533,6 +530,9 @@ class CLRerHead(BaseDenseHead):
         """Test function without test-time augmentation.
         Args:
             feats (tuple[torch.Tensor]): Multi-level features from the FPN.
+            data_samples (List[:obj:`DetDataSample`]): The data samples
+                that include meta information.
+            rescale (bool, optional): Whether to rescale the results.
         Returns:
             result_dict (dict): Inference result containing
                 lanes (List[torch.Tensor]): List of lane tensors (shape: (N, 2))

--- a/libs/models/detectors/__init__.py
+++ b/libs/models/detectors/__init__.py
@@ -1,1 +1,1 @@
-from .clrernet import CLRerNet
+from .clrernet import CLRerNet # noqa: F401

--- a/libs/models/detectors/clrernet.py
+++ b/libs/models/detectors/clrernet.py
@@ -47,16 +47,9 @@ class CLRerNet(SingleStageDetector):
             result_dict (List[dict]): Single-image result containing prediction outputs and
              img_metas as 'result' and 'metas' respectively.
         """
-        assert (
-            img.shape[0] == 1 and len(data_samples) == 1
-        ), "Only single-image test is supported."
-        metainfo = data_samples[0].metainfo
-        metainfo["batch_input_shape"] = tuple(img.size()[-2:])
+        for i in range(len(data_samples)):
+            data_samples[i].metainfo["batch_input_shape"] = tuple(img.size()[-2:])
 
         x = self.extract_feat(img)
-        output = self.bbox_head.predict(x, data_samples)
-        result_dict = {
-            "result": output,
-            "meta": metainfo,
-        }
-        return [result_dict]  # assuming batch size is 1
+        outputs = self.bbox_head.predict(x, data_samples)
+        return outputs

--- a/libs/models/detectors/clrernet.py
+++ b/libs/models/detectors/clrernet.py
@@ -1,8 +1,8 @@
-from mmdet.models.builder import DETECTORS
+from mmdet.registry import MODELS
 from mmdet.models.detectors.single_stage import SingleStageDetector
 
 
-@DETECTORS.register_module()
+@MODELS.register_module()
 class CLRerNet(SingleStageDetector):
     def __init__(
         self,
@@ -11,12 +11,12 @@ class CLRerNet(SingleStageDetector):
         bbox_head,
         train_cfg=None,
         test_cfg=None,
-        pretrained=None,
+        data_preprocessor=None,
         init_cfg=None,
     ):
         """CLRerNet detector."""
         super(CLRerNet, self).__init__(
-            backbone, neck, bbox_head, train_cfg, test_cfg, pretrained, init_cfg
+            backbone, neck, bbox_head, train_cfg, test_cfg, data_preprocessor, init_cfg
         )
 
     def forward_train(self, img, img_metas, **kwargs):
@@ -37,7 +37,7 @@ class CLRerNet(SingleStageDetector):
         losses = self.bbox_head.forward_train(x, img_metas)
         return losses
 
-    def forward_test(self, img, img_metas, **kwargs):
+    def predict(self, img, data_samples, **kwargs):
         """
         Single-image test without augmentation.
         Args:
@@ -48,14 +48,15 @@ class CLRerNet(SingleStageDetector):
              img_metas as 'result' and 'metas' respectively.
         """
         assert (
-            img.shape[0] == 1 and len(img_metas) == 1
+            img.shape[0] == 1 and len(data_samples) == 1
         ), "Only single-image test is supported."
-        img_metas[0]["batch_input_shape"] = tuple(img.size()[-2:])
+        metainfo = data_samples[0].metainfo
+        metainfo["batch_input_shape"] = tuple(img.size()[-2:])
 
         x = self.extract_feat(img)
-        output = self.bbox_head.simple_test(x)
+        output = self.bbox_head.predict(x, data_samples)
         result_dict = {
             "result": output,
-            "meta": img_metas[0],
+            "meta": metainfo,
         }
         return [result_dict]  # assuming batch size is 1

--- a/libs/models/detectors/clrernet.py
+++ b/libs/models/detectors/clrernet.py
@@ -1,5 +1,5 @@
-from mmdet.registry import MODELS
 from mmdet.models.detectors.single_stage import SingleStageDetector
+from mmdet.registry import MODELS
 
 
 @MODELS.register_module()

--- a/libs/models/detectors/clrernet.py
+++ b/libs/models/detectors/clrernet.py
@@ -42,7 +42,8 @@ class CLRerNet(SingleStageDetector):
         Single-image test without augmentation.
         Args:
             img (torch.Tensor): Input image tensor of shape (1, 3, height, width).
-            img_metas (List[dict]): Meta dict containing image information.
+            data_samples (List[:obj:`DetDataSample`]): The data samples
+                that include meta information.
         Returns:
             result_dict (List[dict]): Single-image result containing prediction outputs and
              img_metas as 'result' and 'metas' respectively.

--- a/libs/models/layers/__init__.py
+++ b/libs/models/layers/__init__.py
@@ -1,1 +1,1 @@
-from .attentions import ROIGather
+from .attentions import ROIGather  # noqa: F401

--- a/libs/models/layers/attentions.py
+++ b/libs/models/layers/attentions.py
@@ -1,11 +1,11 @@
-from mmcv.cnn.bricks.registry import ATTENTION
+from mmdet.registry import MODELS
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
 
 
-@ATTENTION.register_module()
+@MODELS.register_module()
 class ROIGather(nn.Module):
     """
     CLRNet ROIGather module to process pooled features

--- a/libs/models/layers/attentions.py
+++ b/libs/models/layers/attentions.py
@@ -1,8 +1,8 @@
-from mmdet.registry import MODELS
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
+from mmdet.registry import MODELS
 
 
 @MODELS.register_module()
@@ -218,8 +218,8 @@ class AnchorVecFeatureMapAttention(nn.Module):
         sim_map = torch.matmul(query, key)
         sim_map = (self.dim**-0.5) * sim_map
         sim_map = F.softmax(sim_map, dim=-1)
-        context = torch.matmul(sim_map, value)  #  [B, Np, C]
-        context = self.W(context)  #  [B, Np, C]
+        context = torch.matmul(sim_map, value)  # [B, Np, C]
+        context = self.W(context)  # [B, Np, C]
         return context
 
 

--- a/libs/models/losses/__init__.py
+++ b/libs/models/losses/__init__.py
@@ -1,3 +1,4 @@
 from .focal_loss import KorniaFocalLoss  # noqa: F401
-from .iou_loss import CLRNetIoULoss, LaneIoULoss  # noqa: F401
+from .iou_loss import CLRNetIoULoss  # noqa: F401
+from .iou_loss import LaneIoULoss  # noqa: F401
 from .seg_loss import CLRNetSegLoss  # noqa: F401

--- a/libs/models/losses/focal_loss.py
+++ b/libs/models/losses/focal_loss.py
@@ -6,7 +6,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from mmdet.models.builder import LOSSES
+from mmdet.registry import MODELS
 
 # Source: https://github.com/kornia/kornia/blob/f4f70fefb63287f72bc80cd96df9c061b1cb60dd/kornia/losses/focal.py
 
@@ -125,7 +125,7 @@ def focal_loss(
     return loss
 
 
-@LOSSES.register_module
+@MODELS.register_module()
 class KorniaFocalLoss(nn.Module):
     r"""Criterion that computes Focal loss.
     According to [1], the Focal loss is computed as follows:

--- a/libs/models/losses/iou_loss.py
+++ b/libs/models/losses/iou_loss.py
@@ -1,8 +1,8 @@
 import torch
-from mmdet.models.builder import LOSSES
+from mmdet.registry import MODELS
 
 
-@LOSSES.register_module
+@MODELS.register_module()
 class CLRNetIoULoss(torch.nn.Module):
     def __init__(self, loss_weight=1.0, lane_width=15 / 800):
         """
@@ -53,7 +53,7 @@ class CLRNetIoULoss(torch.nn.Module):
         return (1 - iou).mean() * self.loss_weight
 
 
-@LOSSES.register_module
+@MODELS.register_module()
 class LaneIoULoss(CLRNetIoULoss):
     def __init__(self, loss_weight=1.0, lane_width=7.5 / 800, img_h=320, img_w=1640):
         """

--- a/libs/models/losses/seg_loss.py
+++ b/libs/models/losses/seg_loss.py
@@ -1,9 +1,9 @@
 import torch
 import torch.nn.functional as F
-from mmdet.models.builder import LOSSES
+from mmdet.registry import MODELS
 
 
-@LOSSES.register_module
+@MODELS.register_module()
 class CLRNetSegLoss(torch.nn.Module):
     def __init__(self, loss_weight=1.0, num_classes=5, ignore_label=255, bg_weight=0.5):
         super(CLRNetSegLoss, self).__init__()

--- a/libs/models/necks/__init__.py
+++ b/libs/models/necks/__init__.py
@@ -1,1 +1,1 @@
-from .clrernet_fpn import CLRerNetFPN
+from .clrernet_fpn import CLRerNetFPN  # noqa: F401

--- a/libs/models/necks/clrernet_fpn.py
+++ b/libs/models/necks/clrernet_fpn.py
@@ -70,7 +70,7 @@ class CLRerNetFPN(nn.Module):
               Example of shapes:
                 ([1, 64, 40, 100], [1, 64, 20, 50], [1, 64, 10, 25]).
         """
-        if type(inputs) == tuple:
+        if isinstance(inputs, tuple):
             inputs = list(inputs)
 
         assert len(inputs) >= len(self.in_channels)  # 4 > 3

--- a/libs/models/necks/clrernet_fpn.py
+++ b/libs/models/necks/clrernet_fpn.py
@@ -8,10 +8,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from mmcv.cnn import ConvModule
-from mmdet.models.builder import NECKS
+from mmdet.registry import MODELS
 
 
-@NECKS.register_module
+@MODELS.register_module()
 class CLRerNetFPN(nn.Module):
     def __init__(self, in_channels, out_channels, num_outs):
         """

--- a/libs/utils/visualizer.py
+++ b/libs/utils/visualizer.py
@@ -52,7 +52,7 @@ def visualize_lanes(
     dst = copy.deepcopy(src)
     for anno in annos:
         dst = draw_lane(anno, dst, dst.shape, width=4, color=GT_COLOR)
-    if pred_ious == None:
+    if pred_ious is None:
         hits = [True for i in range(len(preds))]
     else:
         hits = [iou > iou_thr for iou in pred_ious]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 albumentations==0.4.6
-p_tqdm==1.3.3
+p_tqdm==1.4.2
 pytest
 pytest-cov
 tensorboard

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -1,14 +1,21 @@
 import torch
 from mmdet.apis import init_detector
-
+from mmdet.structures import DetDataSample
 
 def test_clerernet_forward():
     config_path = "configs/clrernet/culane/clrernet_culane_dla34.py"
     model = init_detector(config_path)
     x = torch.ones((1, 3, 320, 800)).float().cuda()
-    img_meta = dict()
+
+    data = dict(
+        inputs=x,
+        data_samples=[DetDataSample()],
+    )
+
+    # forward the model
     with torch.no_grad():
-        results = model(img=x, img_metas=[img_meta], return_loss=False, rescale=True)
+        results = model.test_step(data)
+    print(results)
     assert len(results) == 1
-    assert "result" in results[0]
-    assert "lanes" in results[0]["result"] and "scores" in results[0]["result"]
+    assert "lanes" in results[0]
+    assert "scores" in results[0]

--- a/tools/speed_test.py
+++ b/tools/speed_test.py
@@ -5,13 +5,11 @@ https://github.com/aliyun/conditional-lane-detection/blob/master/tools/condlanen
 import argparse
 
 import cv2
-import mmcv
-import numpy as np
+import mmengine
 import torch
-from mmcv import Config
-from mmcv import DictAction
-from mmcv.runner import load_checkpoint
-from mmdet.models import build_detector
+from mmdet.apis import init_detector
+from mmengine.config import DictAction
+from libs.datasets.pipelines import Compose
 
 torch.backends.cudnn.benchmark = True
 torch.backends.cudnn.deterministic = True
@@ -41,47 +39,46 @@ def parse_args():
 
 def main():
     args = parse_args()
-
-    cfg = Config.fromfile(args.config)
-    if args.cfg_options is not None:
-        cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get("custom_imports", None):
-        from mmcv.utils import import_modules_from_strings
-
-        import_modules_from_strings(**cfg["custom_imports"])
-    # set cudnn_benchmark
-    if cfg.get("cudnn_benchmark", False):
-        torch.backends.cudnn.benchmark = True
-
-    cfg.model.pretrained = None
-    # build the model and load checkpoint
-    model = build_detector(cfg.model, test_cfg=cfg.get("test_cfg"))
-    load_checkpoint(model, args.checkpoint, map_location="cpu")
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    # build the model from a config file and a checkpoint file
+    model = init_detector(args.config, args.checkpoint, device=device)
 
     print("Preparing image", args.filename)
     img = cv2.imread(args.filename)
-    cuty = cfg.crop_bbox[1] if "crop_bbox" in cfg else 0
-    img = img[cuty:, ...]
-    img = cv2.resize(img, cfg.img_scale)
-    mean = np.array(cfg.img_norm_cfg.mean)
-    std = np.array(cfg.img_norm_cfg.std)
-    img = mmcv.imnormalize(img, mean, std, False)
-    img = torch.unsqueeze(torch.tensor(img).permute(2, 0, 1), 0).cuda()
-    model = model.cuda().eval()
-    img_metas = [dict()]
+    ori_shape = img.shape
 
+    cfg = model.cfg
+    model.bbox_head.test_cfg.as_lanes = False
+
+    test_pipeline = Compose(cfg.test_dataloader.dataset.pipeline)
+    data = dict(
+        filename=args.filename,
+        sub_img_name=None,
+        img=img,
+        gt_points=[],
+        id_classes=[],
+        id_instances=[],
+        img_shape=ori_shape,
+        ori_shape=ori_shape,
+    )
+    data = test_pipeline(data)
+    data_ = dict(
+        inputs=[data["inputs"]],
+        data_samples=[data["data_samples"]],
+    )
+
+    # forward the model
     with torch.no_grad():
         # warm up
         print(f"Warming up for {args.n_iter_warmup} iterations.")
         for i in range(args.n_iter_warmup):
-            _ = model(img, img_metas, return_loss=False, rescale=True)
+            _ = model.test_step(data_)
 
         # test
         print(f"Speed test for {args.n_iter_test} iterations.")
-        timer = mmcv.Timer()
+        timer = mmengine.Timer()
         for i in range(args.n_iter_test):
-            _ = model(img, img_metas, return_loss=False, rescale=True)
+            _ = model.test_step(data_)
         t = timer.since_last_check()
         fps = args.n_iter_test / t
         print("##########################")

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,78 +1,44 @@
+# Adapted from:
+# https://github.com/open-mmlab/mmdetection/blob/v3.3.0/tools/test.py
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 import os
 import os.path as osp
-import time
 import warnings
+from copy import deepcopy
 
-# suppress mmcv v2.0.0 announcement
-warnings.filterwarnings('ignore', module='mmcv')
+from mmengine import ConfigDict
+from mmengine.config import Config, DictAction
+from mmengine.runner import Runner
 
-import mmcv
-import torch
-from mmcv.utils import Config, DictAction
-from mmcv.cnn import fuse_conv_bn
-from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
-from mmcv.runner import get_dist_info, init_dist, load_checkpoint, wrap_fp16_model
-
-from mmdet.apis import multi_gpu_test, single_gpu_test
-from mmdet.datasets import build_dataloader, build_dataset, replace_ImageToTensor
-from mmdet.models import build_detector
-
-# suppress mmcv v2.0.0 announcement
-warnings.filterwarnings('ignore', module='mmcv')
+from mmdet.engine.hooks.utils import trigger_visualization_hook
+from mmdet.evaluation import DumpDetResults
+from mmdet.registry import RUNNERS
+from mmdet.utils import setup_cache_size_limit_of_dynamo
 
 
+# TODO: support fuse_conv_bn and format_only
 def parse_args():
-    parser = argparse.ArgumentParser(description='MMDet test (and eval) a model')
+    parser = argparse.ArgumentParser(
+        description='MMDet test (and eval) a model')
     parser.add_argument('config', help='test config file path')
     parser.add_argument('checkpoint', help='checkpoint file')
     parser.add_argument(
         '--work-dir',
-        help='the directory to save the file containing evaluation metrics',
-    )
-    parser.add_argument('--out', help='output result file in pickle format')
+        help='the directory to save the file containing evaluation metrics')
     parser.add_argument(
-        '--fuse-conv-bn',
-        action='store_true',
-        help='Whether to fuse conv and bn, this will slightly increase'
-        'the inference speed',
-    )
-    parser.add_argument(
-        '--format-only',
-        action='store_true',
-        help='Format the output results without perform evaluation. It is'
-        'useful when you want to format the result to a specific format and '
-        'submit it to the test server',
-    )
-    parser.add_argument(
-        '--eval',
+        '--out',
         type=str,
-        default='F1',
-        nargs='+',
-        help='evaluation metrics, which depends on the dataset, e.g., "bbox",'
-        ' "segm", "proposal" for COCO, and "mAP", "recall" for PASCAL VOC',
-    )
-    parser.add_argument('--show', action='store_true', help='show results')
+        help='dump predictions to a pickle file for offline evaluation')
     parser.add_argument(
-        '--show-dir', help='directory where painted images will be saved'
-    )
+        '--show', action='store_true', help='show prediction results')
     parser.add_argument(
-        '--show-score-thr',
-        type=float,
-        default=0.3,
-        help='score threshold (default: 0.3)',
-    )
+        '--show-dir',
+        help='directory where painted images will be saved. '
+        'If specified, it will be automatically saved '
+        'to the work_dir/timestamp/show_dir')
     parser.add_argument(
-        '--gpu-collect',
-        action='store_true',
-        help='whether to use gpu to collect results.',
-    )
-    parser.add_argument(
-        '--tmpdir',
-        help='tmp directory used for collecting results from multiple '
-        'workers, available when gpu-collect is not specified',
-    )
+        '--wait-time', type=float, default=2, help='the interval of show (s)')
     parser.add_argument(
         '--cfg-options',
         nargs='+',
@@ -82,182 +48,103 @@ def parse_args():
         'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
         'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
         'Note that the quotation marks are necessary and that no white space '
-        'is allowed.',
-    )
-    parser.add_argument(
-        '--options',
-        nargs='+',
-        action=DictAction,
-        help='custom options for evaluation, the key-value pair in xxx=yyy '
-        'format will be kwargs for dataset.evaluate() function (deprecate), '
-        'change to --eval-options instead.',
-    )
-    parser.add_argument(
-        '--eval-options',
-        nargs='+',
-        action=DictAction,
-        help='custom options for evaluation, the key-value pair in xxx=yyy '
-        'format will be kwargs for dataset.evaluate() function',
-    )
+        'is allowed.')
     parser.add_argument(
         '--launcher',
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
-        help='job launcher',
-    )
-    parser.add_argument('--local_rank', type=int, default=0)
+        help='job launcher')
+    parser.add_argument('--tta', action='store_true')
+    # When using PyTorch version >= 2.0.0, the `torch.distributed.launch`
+    # will pass the `--local-rank` parameter to `tools/train.py` instead
+    # of `--local_rank`.
+    parser.add_argument('--local_rank', '--local-rank', type=int, default=0)
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)
-
-    if args.options and args.eval_options:
-        raise ValueError(
-            '--options and --eval-options cannot be both '
-            'specified, --options is deprecated in favor of --eval-options'
-        )
-    if args.options:
-        warnings.warn('--options is deprecated in favor of --eval-options')
-        args.eval_options = args.options
     return args
 
 
 def main():
     args = parse_args()
 
-    assert args.out or args.eval or args.format_only or args.show or args.show_dir, (
-        'Please specify at least one operation (save/eval/format/show the '
-        'results / save the results) with the argument "--out", "--eval"'
-        ', "--format-only", "--show" or "--show-dir"'
-    )
+    # Reduce the number of repeated compilations and improve
+    # testing speed.
+    setup_cache_size_limit_of_dynamo()
 
-    if args.eval and args.format_only:
-        raise ValueError('--eval and --format_only cannot be both specified')
-
-    if args.out is not None and not args.out.endswith(('.pkl', '.pickle')):
-        raise ValueError('The output file must be a pkl file.')
-
+    # load config
     cfg = Config.fromfile(args.config)
+    cfg.launcher = args.launcher
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
 
-        import_modules_from_strings(**cfg['custom_imports'])
-    # set cudnn_benchmark
-    if cfg.get('cudnn_benchmark', False):
-        torch.backends.cudnn.benchmark = True
+    # work_dir is determined in this priority: CLI > segment in file > filename
+    if args.work_dir is not None:
+        # update configs according to CLI args if args.work_dir is not None
+        cfg.work_dir = args.work_dir
+    elif cfg.get('work_dir', None) is None:
+        # use config filename as default work_dir if cfg.work_dir is None
+        cfg.work_dir = osp.join('./work_dirs',
+                                osp.splitext(osp.basename(args.config))[0])
 
-    cfg.model.pretrained = None
-    if cfg.model.get('neck'):
-        if isinstance(cfg.model.neck, list):
-            for neck_cfg in cfg.model.neck:
-                if neck_cfg.get('rfp_backbone'):
-                    if neck_cfg.rfp_backbone.get('pretrained'):
-                        neck_cfg.rfp_backbone.pretrained = None
-        elif cfg.model.neck.get('rfp_backbone'):
-            if cfg.model.neck.rfp_backbone.get('pretrained'):
-                cfg.model.neck.rfp_backbone.pretrained = None
+    cfg.load_from = args.checkpoint
 
-    print(f'Config:\n{cfg.pretty_text}')
+    if args.show or args.show_dir:
+        cfg = trigger_visualization_hook(cfg, args)
 
-    # in case the test dataset is concatenated
-    samples_per_gpu = 1
-    if isinstance(cfg.data.test, dict):
-        cfg.data.test.test_mode = True
-        samples_per_gpu = cfg.data.test.pop('samples_per_gpu', 1)
-        if samples_per_gpu > 1:
-            # Replace 'ImageToTensor' to 'DefaultFormatBundle'
-            cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)
-    elif isinstance(cfg.data.test, list):
-        for ds_cfg in cfg.data.test:
-            ds_cfg.test_mode = True
-        samples_per_gpu = max(
-            [ds_cfg.pop('samples_per_gpu', 1) for ds_cfg in cfg.data.test]
-        )
-        if samples_per_gpu > 1:
-            for ds_cfg in cfg.data.test:
-                ds_cfg.pipeline = replace_ImageToTensor(ds_cfg.pipeline)
+    if args.tta:
 
-    # init distributed env first, since logger depends on the dist info.
-    if args.launcher == 'none':
-        distributed = False
+        if 'tta_model' not in cfg:
+            warnings.warn('Cannot find ``tta_model`` in config, '
+                          'we will set it as default.')
+            cfg.tta_model = dict(
+                type='DetTTAModel',
+                tta_cfg=dict(
+                    nms=dict(type='nms', iou_threshold=0.5), max_per_img=100))
+        if 'tta_pipeline' not in cfg:
+            warnings.warn('Cannot find ``tta_pipeline`` in config, '
+                          'we will set it as default.')
+            test_data_cfg = cfg.test_dataloader.dataset
+            while 'dataset' in test_data_cfg:
+                test_data_cfg = test_data_cfg['dataset']
+            cfg.tta_pipeline = deepcopy(test_data_cfg.pipeline)
+            flip_tta = dict(
+                type='TestTimeAug',
+                transforms=[
+                    [
+                        dict(type='RandomFlip', prob=1.),
+                        dict(type='RandomFlip', prob=0.)
+                    ],
+                    [
+                        dict(
+                            type='PackDetInputs',
+                            meta_keys=('img_id', 'img_path', 'ori_shape',
+                                       'img_shape', 'scale_factor', 'flip',
+                                       'flip_direction'))
+                    ],
+                ])
+            cfg.tta_pipeline[-1] = flip_tta
+        cfg.model = ConfigDict(**cfg.tta_model, module=cfg.model)
+        cfg.test_dataloader.dataset.pipeline = cfg.tta_pipeline
+
+    # build the runner from config
+    if 'runner_type' not in cfg:
+        # build the default runner
+        runner = Runner.from_cfg(cfg)
     else:
-        distributed = True
-        init_dist(args.launcher, **cfg.dist_params)
+        # build customized runner from the registry
+        # if 'runner_type' is set in the cfg
+        runner = RUNNERS.build(cfg)
 
-    rank, _ = get_dist_info()
-    # allows not to create
-    if args.work_dir is not None and rank == 0:
-        mmcv.mkdir_or_exist(osp.abspath(args.work_dir))
-        timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
-        json_file = osp.join(args.work_dir, f'eval_{timestamp}.json')
+    # add `DumpResults` dummy metric
+    if args.out is not None:
+        assert args.out.endswith(('.pkl', '.pickle')), \
+            'The dump file must be a pkl file.'
+        runner.test_evaluator.metrics.append(
+            DumpDetResults(out_file_path=args.out))
 
-    # build the dataloader
-    dataset = build_dataset(cfg.data.test)
-    data_loader = build_dataloader(
-        dataset,
-        samples_per_gpu=samples_per_gpu,
-        workers_per_gpu=cfg.data.workers_per_gpu,
-        dist=distributed,
-        shuffle=False,
-    )
-
-    # build the model and load checkpoint
-    # cfg.model.train_cfg = None
-    model = build_detector(cfg.model, test_cfg=cfg.get('test_cfg'))
-    fp16_cfg = cfg.get('fp16', None)
-    if fp16_cfg is not None:
-        wrap_fp16_model(model)
-    checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')
-    if args.fuse_conv_bn:
-        model = fuse_conv_bn(model)
-    # old versions did not save class info in checkpoints, this walkaround is
-    # for backward compatibility
-    if 'CLASSES' in checkpoint.get('meta', {}):
-        model.CLASSES = checkpoint['meta']['CLASSES']
-    else:
-        model.CLASSES = dataset.CLASSES
-
-    if not distributed:
-        model = MMDataParallel(model, device_ids=[0])
-        outputs = single_gpu_test(
-            model, data_loader, args.show, args.show_dir, args.show_score_thr
-        )
-    else:
-        model = MMDistributedDataParallel(
-            model.cuda(),
-            device_ids=[torch.cuda.current_device()],
-            broadcast_buffers=False,
-        )
-        outputs = multi_gpu_test(model, data_loader, args.tmpdir, args.gpu_collect)
-
-    rank, _ = get_dist_info()
-    if rank == 0:
-        if args.out:
-            print(f'\nwriting results to {args.out}')
-            mmcv.dump(outputs, args.out)
-        kwargs = {} if args.eval_options is None else args.eval_options
-        if args.format_only:
-            dataset.format_results(outputs, **kwargs)
-        if args.eval:
-            eval_kwargs = cfg.get('evaluation', {}).copy()
-            # hard-code way to remove EvalHook args
-            for key in [
-                'interval',
-                'tmpdir',
-                'start',
-                'gpu_collect',
-                'save_best',
-                'rule',
-            ]:
-                eval_kwargs.pop(key, None)
-            eval_kwargs.update(dict(metric=args.eval, **kwargs))
-            metric = dataset.evaluate(outputs, **eval_kwargs)
-            metric = {k: float(v) for k, v in metric.items()}
-            metric_dict = dict(config=args.config, metric=metric)
-            if args.work_dir is not None and rank == 0:
-                mmcv.dump(metric_dict, json_file)
+    # start testing
+    runner.test()
 
 
 if __name__ == '__main__':

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,93 +1,60 @@
 # Adapted from:
-# https://github.com/open-mmlab/mmdetection/blob/db256a14bb7018ad36eed104ea0ce178a0d4050c/tools/train.py
+# https://github.com/open-mmlab/mmdetection/blob/v3.3.0/tools/train.py
 # Copyright (c) OpenMMLab. All rights reserved.
-
 import argparse
-import copy
 import os
 import os.path as osp
-import time
-import warnings
 
-import torch
-from mmcv.runner import get_dist_info, init_dist
-from mmcv.utils import Config, DictAction, get_git_hash, mkdir_or_exist
-from mmdet import __version__
-from mmdet.apis import set_random_seed, train_detector
-from mmdet.datasets import build_dataset
-from mmdet.models import build_detector
-from mmdet.utils import collect_env, get_device, get_root_logger
+from mmengine.config import Config, DictAction
+from mmengine.registry import RUNNERS
+from mmengine.runner import Runner
 
-# suppress mmcv v2.0.0 announcement
-warnings.filterwarnings("ignore", module="mmcv")
+from mmdet.utils import setup_cache_size_limit_of_dynamo
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Train a detector")
-    parser.add_argument("config", help="train config file path")
-    parser.add_argument("--work-dir", help="the dir to save logs and models")
-    parser.add_argument("--resume-from", help="the checkpoint file to resume from")
+    parser = argparse.ArgumentParser(description='Train a detector')
+    parser.add_argument('config', help='train config file path')
+    parser.add_argument('--work-dir', help='the dir to save logs and models')
     parser.add_argument(
-        "--no-validate",
-        action="store_true",
-        help="whether not to evaluate the checkpoint during training",
-    )
-    group_gpus = parser.add_mutually_exclusive_group()
-    group_gpus.add_argument(
-        "--gpus",
-        type=int,
-        help="number of gpus to use " "(only applicable to non-distributed training)",
-    )
-    group_gpus.add_argument(
-        "--gpu-ids",
-        type=int,
-        nargs="+",
-        help="ids of gpus to use " "(only applicable to non-distributed training)",
-    )
-    parser.add_argument("--seed", type=int, default=None, help="random seed")
+        '--amp',
+        action='store_true',
+        default=False,
+        help='enable automatic-mixed-precision training')
     parser.add_argument(
-        "--deterministic",
-        action="store_true",
-        help="whether to set deterministic options for CUDNN backend.",
-    )
+        '--auto-scale-lr',
+        action='store_true',
+        help='enable automatically scaling LR.')
     parser.add_argument(
-        "--options",
-        nargs="+",
+        '--resume',
+        nargs='?',
+        type=str,
+        const='auto',
+        help='If specify checkpoint path, resume from it, while if not '
+        'specify, try to auto resume from the latest checkpoint '
+        'in the work directory.')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
         action=DictAction,
-        help="override some settings in the used config, the key-value pair "
-        "in xxx=yyy format will be merged into config file (deprecate), "
-        "change to --cfg-options instead.",
-    )
-    parser.add_argument(
-        "--cfg-options",
-        nargs="+",
-        action=DictAction,
-        help="override some settings in the used config, the key-value pair "
-        "in xxx=yyy format will be merged into config file. If the value to "
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
         'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
         'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
-        "Note that the quotation marks are necessary and that no white space "
-        "is allowed.",
-    )
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     parser.add_argument(
-        "--launcher",
-        choices=["none", "pytorch", "slurm", "mpi"],
-        default="none",
-        help="job launcher",
-    )
-    parser.add_argument("--local_rank", type=int, default=0)
+        '--launcher',
+        choices=['none', 'pytorch', 'slurm', 'mpi'],
+        default='none',
+        help='job launcher')
+    # When using PyTorch version >= 2.0.0, the `torch.distributed.launch`
+    # will pass the `--local-rank` parameter to `tools/train.py` instead
+    # of `--local_rank`.
+    parser.add_argument('--local_rank', '--local-rank', type=int, default=0)
     args = parser.parse_args()
-    if "LOCAL_RANK" not in os.environ:
-        os.environ["LOCAL_RANK"] = str(args.local_rank)
-
-    if args.options and args.cfg_options:
-        raise ValueError(
-            "--options and --cfg-options cannot be both "
-            "specified, --options is deprecated in favor of --cfg-options"
-        )
-    if args.options:
-        warnings.warn("--options is deprecated in favor of --cfg-options")
-        args.cfg_options = args.options
+    if 'LOCAL_RANK' not in os.environ:
+        os.environ['LOCAL_RANK'] = str(args.local_rank)
 
     return args
 
@@ -95,109 +62,62 @@ def parse_args():
 def main():
     args = parse_args()
 
+    # Reduce the number of repeated compilations and improve
+    # training speed.
+    setup_cache_size_limit_of_dynamo()
+
+    # load config
     cfg = Config.fromfile(args.config)
+    cfg.launcher = args.launcher
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get("custom_imports", None):
-        from mmcv.utils import import_modules_from_strings
-
-        import_modules_from_strings(**cfg["custom_imports"])
-    # set cudnn_benchmark
-    if cfg.get("cudnn_benchmark", False):
-        torch.backends.cudnn.benchmark = True
 
     # work_dir is determined in this priority: CLI > segment in file > filename
     if args.work_dir is not None:
         # update configs according to CLI args if args.work_dir is not None
         cfg.work_dir = args.work_dir
-    elif cfg.get("work_dir", None) is None:
+    elif cfg.get('work_dir', None) is None:
         # use config filename as default work_dir if cfg.work_dir is None
-        cfg.work_dir = osp.join(
-            "./work_dirs", osp.splitext(osp.basename(args.config))[0]
-        )
-    if args.resume_from is not None:
-        cfg.resume_from = args.resume_from
-    if args.gpu_ids is not None:
-        cfg.gpu_ids = args.gpu_ids
-        if len(args.gpu_ids) == 1:
-            torch.cuda.set_device(args.gpu_ids[0])
+        cfg.work_dir = osp.join('./work_dirs',
+                                osp.splitext(osp.basename(args.config))[0])
+
+    # enable automatic-mixed-precision training
+    if args.amp is True:
+        cfg.optim_wrapper.type = 'AmpOptimWrapper'
+        cfg.optim_wrapper.loss_scale = 'dynamic'
+
+    # enable automatically scaling LR
+    if args.auto_scale_lr:
+        if 'auto_scale_lr' in cfg and \
+                'enable' in cfg.auto_scale_lr and \
+                'base_batch_size' in cfg.auto_scale_lr:
+            cfg.auto_scale_lr.enable = True
+        else:
+            raise RuntimeError('Can not find "auto_scale_lr" or '
+                               '"auto_scale_lr.enable" or '
+                               '"auto_scale_lr.base_batch_size" in your'
+                               ' configuration file.')
+
+    # resume is determined in this priority: resume from > auto_resume
+    if args.resume == 'auto':
+        cfg.resume = True
+        cfg.load_from = None
+    elif args.resume is not None:
+        cfg.resume = True
+        cfg.load_from = args.resume
+
+    # build the runner from config
+    if 'runner_type' not in cfg:
+        # build the default runner
+        runner = Runner.from_cfg(cfg)
     else:
-        cfg.gpu_ids = range(1) if args.gpus is None else range(args.gpus)
+        # build customized runner from the registry
+        # if 'runner_type' is set in the cfg
+        runner = RUNNERS.build(cfg)
 
-    # init distributed env first, since logger depends on the dist info.
-    if args.launcher == "none":
-        distributed = False
-    else:
-        distributed = True
-        init_dist(args.launcher, **cfg.dist_params)
-        # re-set gpu_ids with distributed training mode
-        _, world_size = get_dist_info()
-        cfg.gpu_ids = range(world_size)
-
-    # create work_dir
-    mkdir_or_exist(osp.abspath(cfg.work_dir))
-    # dump config
-    cfg.dump(osp.join(cfg.work_dir, osp.basename(args.config)))
-    # init the logger before other steps
-    timestamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
-    log_file = osp.join(cfg.work_dir, f"{timestamp}.log")
-    logger = get_root_logger(log_file=log_file, log_level=cfg.log_level)
-
-    # init the meta dict to record some important information such as
-    # environment info and seed, which will be logged
-    meta = dict()
-    # log env info
-    env_info_dict = collect_env()
-    env_info = "\n".join([(f"{k}: {v}") for k, v in env_info_dict.items()])
-    dash_line = "-" * 60 + "\n"
-    logger.info("Environment info:\n" + dash_line + env_info + "\n" + dash_line)
-    meta["env_info"] = env_info
-    meta["config"] = cfg.pretty_text
-    # log some basic info
-    logger.info(f"Distributed training: {distributed}")
-    logger.info(f"Config:\n{cfg.pretty_text}")
-
-    # set random seeds
-    if args.seed is not None:
-        logger.info(
-            f"Set random seed to {args.seed}, " f"deterministic: {args.deterministic}"
-        )
-        set_random_seed(args.seed, deterministic=args.deterministic)
-    cfg.seed = args.seed
-    meta["seed"] = args.seed
-    meta["exp_name"] = osp.basename(args.config)
-
-    model = build_detector(
-        cfg.model, train_cfg=cfg.get("train_cfg"), test_cfg=cfg.get("test_cfg")
-    )
-    model.init_weights()
-
-    datasets = [build_dataset(cfg.data.train)]
-    if len(cfg.workflow) == 2:
-        val_dataset = copy.deepcopy(cfg.data.val)
-        val_dataset.pipeline = cfg.data.train.pipeline
-        datasets.append(build_dataset(val_dataset))
-    if cfg.checkpoint_config is not None:
-        # save mmdet version, config file content and class names in
-        # checkpoints as meta data
-        cfg.checkpoint_config.meta = dict(
-            mmdet_version=__version__ + get_git_hash()[:7], CLASSES=datasets[0].CLASSES
-        )
-    cfg.device = get_device()
-
-    # add an attribute for visualization convenience
-    model.CLASSES = datasets[0].CLASSES
-    train_detector(
-        model,
-        datasets,
-        cfg,
-        distributed=distributed,
-        validate=(not args.no_validate),
-        timestamp=timestamp,
-        meta=meta,
-    )
+    # start training
+    runner.train()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR provides:
- Docker container of MMDetection 3.3 environment on nvidia/cuda:12.1.1-devel-ubuntu22.04 image
- Minimum update for mmv3 training and test 
- Reproduced test result with the [mmv2 CLRerNet model](https://github.com/hirotomusiker/CLRerNet/releases/download/v0.1.0/clrernet_culane_dla34.pth) 
- Reproduced train result (F1@50=81.03 81.48 (EMA), as follows)
- Reproduced demo result
- Reproduced speed test result

baseline CLRerNet model
```
python tools/train.py configs/clrernet/culane/clrernet_culane_dla34.py 
python tools/test.py configs/clrernet/culane/clrernet_culane_dla34.py work_dirs/clrernet_culane_dla34/epoch_15.pth

03/12 07:08:13 - mmengine - INFO - Evaluation results for IoU threshold = 0.1                                                                                       
03/12 07:08:13 - mmengine - INFO - Eval category: test_all    , N: 34680, TP: 85947, FP:  4373, FN: 18939, Precision: 0.9516, Recall: 0.8194, F1: 0.8806            
03/12 07:08:13 - mmengine - INFO - Eval category: test0_normal, N: 9621, TP: 31816, FP:   371, FN:   961, Precision: 0.9885, Recall: 0.9707, F1: 0.9795             
03/12 07:08:13 - mmengine - INFO - Eval category: test1_crowd , N: 8113, TP: 22862, FP:   682, FN:  5141, Precision: 0.9710, Recall: 0.8164, F1: 0.8870             
03/12 07:08:13 - mmengine - INFO - Eval category: test2_hlight, N:  486, TP:  1265, FP:    41, FN:   420, Precision: 0.9686, Recall: 0.7507, F1: 0.8459
03/12 07:08:13 - mmengine - INFO - Eval category: test3_shadow, N:  930, TP:  2392, FP:   112, FN:   484, Precision: 0.9553, Recall: 0.8317, F1: 0.8892
03/12 07:08:13 - mmengine - INFO - Eval category: test4_noline, N: 4067, TP:  7400, FP:   815, FN:  6621, Precision: 0.9008, Recall: 0.5278, F1: 0.6656
03/12 07:08:13 - mmengine - INFO - Eval category: test5_arrow , N:  890, TP:  2931, FP:    72, FN:   251, Precision: 0.9760, Recall: 0.9211, F1: 0.9478            
03/12 07:08:13 - mmengine - INFO - Eval category: test6_curve , N:  422, TP:  1021, FP:    21, FN:   291, Precision: 0.9798, Recall: 0.7782, F1: 0.8675
03/12 07:08:13 - mmengine - INFO - Eval category: test7_cross , N: 3122, TP:     0, FP:  1241, FN:     0, Precision: 0.0000, Recall: 0.0000, F1: 0.0000            
03/12 07:08:13 - mmengine - INFO - Eval category: test8_night , N: 7029, TP: 16260, FP:  1018, FN:  4770, Precision: 0.9411, Recall: 0.7732, F1: 0.8489            
03/12 07:08:13 - mmengine - INFO - Evaluation results for IoU threshold = 0.5                                                                                       
03/12 07:08:13 - mmengine - INFO - Eval category: test_all    , N: 34680, TP: 79092, FP: 11228, FN: 25794, Precision: 0.8757, Recall: 0.7541, F1: 0.8103           
03/12 07:08:13 - mmengine - INFO - Eval category: test0_normal, N: 9621, TP: 30555, FP:  1632, FN:  2222, Precision: 0.9493, Recall: 0.9322, F1: 0.9407
03/12 07:08:13 - mmengine - INFO - Eval category: test1_crowd , N: 8113, TP: 20600, FP:  2944, FN:  7403, Precision: 0.8750, Recall: 0.7356, F1: 0.7993             
03/12 07:08:13 - mmengine - INFO - Eval category: test2_hlight, N:  486, TP:  1125, FP:   181, FN:   560, Precision: 0.8614, Recall: 0.6677, F1: 0.7523             
03/12 07:08:13 - mmengine - INFO - Eval category: test3_shadow, N:  930, TP:  2246, FP:   258, FN:   630, Precision: 0.8970, Recall: 0.7809, F1: 0.8349
03/12 07:08:13 - mmengine - INFO - Eval category: test4_noline, N: 4067, TP:  6229, FP:  1986, FN:  7792, Precision: 0.7582, Recall: 0.4443, F1: 0.5603
03/12 07:08:13 - mmengine - INFO - Eval category: test5_arrow , N:  890, TP:  2802, FP:   201, FN:   380, Precision: 0.9331, Recall: 0.8806, F1: 0.9061
03/12 07:08:13 - mmengine - INFO - Eval category: test6_curve , N:  422, TP:   870, FP:   172, FN:   442, Precision: 0.8349, Recall: 0.6631, F1: 0.7392
03/12 07:08:13 - mmengine - INFO - Eval category: test7_cross , N: 3122, TP:     0, FP:  1241, FN:     0, Precision: 0.0000, Recall: 0.0000, F1: 0.0000
03/12 07:08:13 - mmengine - INFO - Eval category: test8_night , N: 7029, TP: 14665, FP:  2613, FN:  6365, Precision: 0.8488, Recall: 0.6973, F1: 0.7656
03/12 07:08:13 - mmengine - INFO - Evaluation results for IoU threshold = 0.75                                                                                      
03/12 07:08:13 - mmengine - INFO - Eval category: test_all    , N: 34680, TP: 62287, FP: 28033, FN: 42599, Precision: 0.6896, Recall: 0.5939, F1: 0.6382
03/12 07:08:13 - mmengine - INFO - Eval category: test0_normal, N: 9621, TP: 25993, FP:  6194, FN:  6784, Precision: 0.8076, Recall: 0.7930, F1: 0.8002             
03/12 07:08:13 - mmengine - INFO - Eval category: test1_crowd , N: 8113, TP: 16097, FP:  7447, FN: 11906, Precision: 0.6837, Recall: 0.5748, F1: 0.6246
03/12 07:08:13 - mmengine - INFO - Eval category: test2_hlight, N:  486, TP:   776, FP:   530, FN:   909, Precision: 0.5942, Recall: 0.4605, F1: 0.5189
03/12 07:08:13 - mmengine - INFO - Eval category: test3_shadow, N:  930, TP:  1563, FP:   941, FN:  1313, Precision: 0.6242, Recall: 0.5435, F1: 0.5810             
03/12 07:08:13 - mmengine - INFO - Eval category: test4_noline, N: 4067, TP:  4370, FP:  3845, FN:  9651, Precision: 0.5320, Recall: 0.3117, F1: 0.3931             
03/12 07:08:13 - mmengine - INFO - Eval category: test5_arrow , N:  890, TP:  2368, FP:   635, FN:   814, Precision: 0.7885, Recall: 0.7442, F1: 0.7657
03/12 07:08:13 - mmengine - INFO - Eval category: test6_curve , N:  422, TP:   460, FP:   582, FN:   852, Precision: 0.4415, Recall: 0.3506, F1: 0.3908             
03/12 07:08:13 - mmengine - INFO - Eval category: test7_cross , N: 3122, TP:     0, FP:  1241, FN:     0, Precision: 0.0000, Recall: 0.0000, F1: 0.0000             
03/12 07:08:13 - mmengine - INFO - Eval category: test8_night , N: 7029, TP: 10660, FP:  6618, FN: 10370, Precision: 0.6170, Recall: 0.5069, F1: 0.5565 
```

EMA model
```
python tools/train.py configs/clrernet/culane/clrernet_culane_dla34_ema.py
python tools/test.py configs/clrernet/culane/clrernet_culane_dla34_ema.py work_dirs/clrernet_culane_dla34_ema/epoch_50.pth
03/15 09:25:29 - mmengine - INFO - Evaluation results for IoU threshold = 0.1
03/15 09:25:29 - mmengine - INFO - Eval category: test_all    , N: 34680, TP: 87698, FP:  5330, FN: 17188, Precision: 0.9427, Recall: 0.8361, F1: 0.8862
03/15 09:25:29 - mmengine - INFO - Eval category: test0_normal, N: 9621, TP: 31987, FP:   441, FN:   790, Precision: 0.9864, Recall: 0.9759, F1: 0.9811
03/15 09:25:29 - mmengine - INFO - Eval category: test1_crowd , N: 8113, TP: 23305, FP:   930, FN:  4698, Precision: 0.9616, Recall: 0.8322, F1: 0.8923
03/15 09:25:29 - mmengine - INFO - Eval category: test2_hlight, N:  486, TP:  1328, FP:    63, FN:   357, Precision: 0.9547, Recall: 0.7881, F1: 0.8635
03/15 09:25:29 - mmengine - INFO - Eval category: test3_shadow, N:  930, TP:  2456, FP:   111, FN:   420, Precision: 0.9568, Recall: 0.8540, F1: 0.9024
03/15 09:25:29 - mmengine - INFO - Eval category: test4_noline, N: 4067, TP:  7974, FP:   999, FN:  6047, Precision: 0.8887, Recall: 0.5687, F1: 0.6936
03/15 09:25:29 - mmengine - INFO - Eval category: test5_arrow , N:  890, TP:  2963, FP:    75, FN:   219, Precision: 0.9753, Recall: 0.9312, F1: 0.9527
03/15 09:25:29 - mmengine - INFO - Eval category: test6_curve , N:  422, TP:  1076, FP:    22, FN:   236, Precision: 0.9800, Recall: 0.8201, F1: 0.8929
03/15 09:25:29 - mmengine - INFO - Eval category: test7_cross , N: 3122, TP:     0, FP:  1594, FN:     0, Precision: 0.0000, Recall: 0.0000, F1: 0.0000
03/15 09:25:29 - mmengine - INFO - Eval category: test8_night , N: 7029, TP: 16609, FP:  1095, FN:  4421, Precision: 0.9381, Recall: 0.7898, F1: 0.8576
03/15 09:25:29 - mmengine - INFO - Evaluation results for IoU threshold = 0.5
03/15 09:25:29 - mmengine - INFO - Eval category: test_all    , N: 34680, TP: 80626, FP: 12402, FN: 24260, Precision: 0.8667, Recall: 0.7687, F1: 0.8148
03/15 09:25:29 - mmengine - INFO - Eval category: test0_normal, N: 9621, TP: 30780, FP:  1648, FN:  1997, Precision: 0.9492, Recall: 0.9391, F1: 0.9441
03/15 09:25:29 - mmengine - INFO - Eval category: test1_crowd , N: 8113, TP: 21056, FP:  3179, FN:  6947, Precision: 0.8688, Recall: 0.7519, F1: 0.8062
03/15 09:25:29 - mmengine - INFO - Eval category: test2_hlight, N:  486, TP:  1173, FP:   218, FN:   512, Precision: 0.8433, Recall: 0.6961, F1: 0.7627
03/15 09:25:29 - mmengine - INFO - Eval category: test3_shadow, N:  930, TP:  2304, FP:   263, FN:   572, Precision: 0.8975, Recall: 0.8011, F1: 0.8466
03/15 09:25:29 - mmengine - INFO - Eval category: test4_noline, N: 4067, TP:  6609, FP:  2364, FN:  7412, Precision: 0.7365, Recall: 0.4714, F1: 0.5748
03/15 09:25:29 - mmengine - INFO - Eval category: test5_arrow , N:  890, TP:  2833, FP:   205, FN:   349, Precision: 0.9325, Recall: 0.8903, F1: 0.9109
03/15 09:25:29 - mmengine - INFO - Eval category: test6_curve , N:  422, TP:   956, FP:   142, FN:   356, Precision: 0.8707, Recall: 0.7287, F1: 0.7934
03/15 09:25:29 - mmengine - INFO - Eval category: test7_cross , N: 3122, TP:     0, FP:  1594, FN:     0, Precision: 0.0000, Recall: 0.0000, F1: 0.0000
03/15 09:25:29 - mmengine - INFO - Eval category: test8_night , N: 7029, TP: 14915, FP:  2789, FN:  6115, Precision: 0.8425, Recall: 0.7092, F1: 0.7701
03/15 09:25:29 - mmengine - INFO - Evaluation results for IoU threshold = 0.75
03/15 09:25:29 - mmengine - INFO - Eval category: test_all    , N: 34680, TP: 64135, FP: 28893, FN: 40751, Precision: 0.6894, Recall: 0.6115, F1: 0.6481
03/15 09:25:29 - mmengine - INFO - Eval category: test0_normal, N: 9621, TP: 26332, FP:  6096, FN:  6445, Precision: 0.8120, Recall: 0.8034, F1: 0.8077
03/15 09:25:29 - mmengine - INFO - Eval category: test1_crowd , N: 8113, TP: 16441, FP:  7794, FN: 11562, Precision: 0.6784, Recall: 0.5871, F1: 0.6295
03/15 09:25:29 - mmengine - INFO - Eval category: test2_hlight, N:  486, TP:   800, FP:   591, FN:   885, Precision: 0.5751, Recall: 0.4748, F1: 0.5202
03/15 09:25:29 - mmengine - INFO - Eval category: test3_shadow, N:  930, TP:  1690, FP:   877, FN:  1186, Precision: 0.6584, Recall: 0.5876, F1: 0.6210
03/15 09:25:29 - mmengine - INFO - Eval category: test4_noline, N: 4067, TP:  4709, FP:  4264, FN:  9312, Precision: 0.5248, Recall: 0.3359, F1: 0.4096
03/15 09:25:29 - mmengine - INFO - Eval category: test5_arrow , N:  890, TP:  2414, FP:   624, FN:   768, Precision: 0.7946, Recall: 0.7586, F1: 0.7762
03/15 09:25:29 - mmengine - INFO - Eval category: test6_curve , N:  422, TP:   616, FP:   482, FN:   696, Precision: 0.5610, Recall: 0.4695, F1: 0.5112
03/15 09:25:29 - mmengine - INFO - Eval category: test7_cross , N: 3122, TP:     0, FP:  1594, FN:     0, Precision: 0.0000, Recall: 0.0000, F1: 0.0000
03/15 09:25:29 - mmengine - INFO - Eval category: test8_night , N: 7029, TP: 11133, FP:  6571, FN:  9897, Precision: 0.6288, Recall: 0.5294, F1: 0.5748
```


Unittest results
```
---------- coverage: platform linux, python 3.11.9-final-0 -----------
Name                                                Stmts   Miss  Cover
-----------------------------------------------------------------------
libs/core/anchor/__init__.py                            1      0   100%
libs/core/anchor/anchor_generator.py                   41      0   100%
libs/core/bbox/__init__.py                              2      0   100%
libs/core/bbox/assigners/dynamic_topk_assigner.py      76     57    25%
libs/core/bbox/match_costs/__init__.py                  1      0   100%
libs/core/bbox/match_costs/match_cost.py               99     16    84%
libs/core/hook/__init__.py                              1      0   100%
libs/core/hook/logger.py                               12      7    42%
libs/datasets/__init__.py                               2      0   100%
libs/datasets/culane_dataset.py                        99     56    43%
libs/datasets/metrics/culane_metric.py                134    107    20%
libs/datasets/pipelines/__init__.py                     3      0   100%
libs/datasets/pipelines/alaug.py                      154    117    24%
libs/datasets/pipelines/compose.py                     30     14    53%
libs/datasets/pipelines/lane_formatting.py             64     44    31%
libs/models/__init__.py                                 6      0   100%
libs/models/backbones/__init__.py                       1      0   100%
libs/models/backbones/dla.py                          220     73    67%
libs/models/dense_heads/__init__.py                     1      0   100%
libs/models/dense_heads/clrernet_head.py              224     61    73%
libs/models/dense_heads/seg_decoder.py                 14      4    71%
libs/models/detectors/__init__.py                       1      0   100%
libs/models/detectors/clrernet.py                      17      4    76%
libs/models/layers/__init__.py                          1      0   100%
libs/models/layers/attentions.py                       74      0   100%
libs/models/losses/__init__.py                          3      0   100%
libs/models/losses/focal_loss.py                       52     35    33%
libs/models/losses/iou_loss.py                         50      0   100%
libs/models/losses/seg_loss.py                         17      4    76%
libs/models/necks/__init__.py                           1      0   100%
libs/models/necks/clrernet_fpn.py                      36      1    97%
libs/utils/lane_utils.py                               57     38    33%
libs/utils/visualizer.py                               28     20    29%
-----------------------------------------------------------------------
TOTAL                                                1522    658    57%

================================================================== 6 passed, 3 warnings in 7.43s ===========================================================
```