### PR TITLE
fix assigner corner case bug

### DIFF
--- a/libs/core/bbox/assigners/dynamic_topk_assigner.py
+++ b/libs/core/bbox/assigners/dynamic_topk_assigner.py
@@ -76,7 +76,7 @@ class DynamicTopkAssigner(BaseAssigner):
         matched_gt = matching_matrix.sum(1)
         if (matched_gt > 1).sum() > 0:
             _, cost_argmin = torch.min(cost[matched_gt > 1, :], dim=1)
-            matching_matrix[matched_gt > 1, 0] *= 0.0
+            matching_matrix[matched_gt > 1, :] *= 0.0
             matching_matrix[matched_gt > 1, cost_argmin] = 1.0
 
         prior_idx = matching_matrix.sum(1).nonzero()


### PR DESCRIPTION
https://github.com/hirotomusiker/CLRerNet/issues/77

This PR fixes the corner-case bug in dynamic top-k assigner.

The line deals with the corner case where multiple GT lanes are assigned to one prior (anchor). 
The goal is to 'reset' the assignment and re-assign one GT for the prior.
The bug could result in a minor training issue. The loss for the prior would not work well.

The empirical comparison (5 seeds) shows no significant change (0.3%)
```
before: [0.8093, 0.8085, 0.8116, 0.8120, 0.8106] -> 81.04±0.13
after:  [0.8098,  0.8087, 0.8115, 0.8108, 0.8123] -> 81.06±0.12
```