### PR TITLE
Migrate to albumentationsx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-albumentations==0.4.6
+albumentationsx==2.0.12
 p_tqdm==1.4.2
 pytest
 pytest-cov


### PR DESCRIPTION
[albumentations](https://github.com/albumentations-team/albumentations) has been deprecated 10th July 2025
Upgrade is required for using NumPy 2.x, since imgaug, one of albumentations dependencies, is also abandoned and does not support 2.x


_The following might be a problem_
albumentationsx has dual licensing:
- AGPL-3.0 License: Free for open-source projects
- Commercial License: For proprietary/commercial use

This would fix #82 